### PR TITLE
Better dual contouring

### DIFF
--- a/bind/guile/test/mesh-test-suite.scm
+++ b/bind/guile/test/mesh-test-suite.scm
@@ -72,7 +72,7 @@
 
 (define start-time (get-internal-real-time))
 (ao-export-mesh charm "meshes/charm.stl" '(-2 -2 -2) '(2 2 2) 100)
-(format #t "Exported charm in ~f sec\n"
+(format #t "Exported charm in ~a sec\n"
         (/ (- (get-internal-real-time) start-time 0.0)
            internal-time-units-per-second))
 

--- a/bind/guile/test/mesh-test-suite.scm
+++ b/bind/guile/test/mesh-test-suite.scm
@@ -31,6 +31,16 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(define (diamond x y z)
+  (max (+ x y -1)
+       (- x y 1)
+       (- y x 1)
+       (- -1 x y)))
+(ao-export-mesh (extrude-z diamond -1 1)
+                "meshes/diamond.stl" '(-2.1 -2.1 -2.1) '(2.1 2.1 2.1) 4)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 ;; How do edges and vertex placement look?
 (define (slice x y z) (+ x y z -2.73))
 (define split (intersection (cube '(-1.5 -1.5 -1.5) '(1.5 1.5 1.5)) slice))
@@ -75,4 +85,3 @@
 (format #t "Exported charm in ~a sec\n"
         (/ (- (get-internal-real-time) start-time 0.0)
            internal-time-units-per-second))
-

--- a/bind/guile/test/mesh-test-suite.scm
+++ b/bind/guile/test/mesh-test-suite.scm
@@ -73,6 +73,6 @@
 (define start-time (get-internal-real-time))
 (ao-export-mesh charm "meshes/charm.stl" '(-2 -2 -2) '(2 2 2) 100)
 (format #t "Exported charm in ~f sec\n"
-        (/ (- (get-internal-real-time) start-time)
+        (/ (- (get-internal-real-time) start-time 0.0)
            internal-time-units-per-second))
 

--- a/doc/references.md
+++ b/doc/references.md
@@ -2,6 +2,10 @@ Gerstner, T., and Pajarola, R. 2000.
 "Topology preserving and controlled topology simplifying multiresolution isosurface extraction."
 IEEE Visualization 2000, 259–266.
 
+S. Schaefer, and J. Warren
+"Dual Contouring: The Secret Sauce"
+2003
+
 T. Ju, F. Losasso, S. Schaefer, and J. Warren,
 "Dual contouring of hermite data,"
 ACM Transactions on Graphics, vol. 21, no. 3, pp. 339– 346,

--- a/kernel/include/ao/kernel/format/contours.hpp
+++ b/kernel/include/ao/kernel/format/contours.hpp
@@ -28,8 +28,7 @@ class Region;
 
 struct Contours
 {
-    static Contours Render(Tree* t, const Region& r,
-                           uint32_t flags=Quadtree::COLLAPSE);
+    static Contours Render(Tree* t, const Region& r);
 
     /*
      *  Saves the given contours as an SVG file

--- a/kernel/include/ao/kernel/format/mesh.hpp
+++ b/kernel/include/ao/kernel/format/mesh.hpp
@@ -36,8 +36,7 @@ struct Mesh
      *  simplification to collapse leaf cells), then using DC to generate
      *  a triangle mesh.
      */
-    static Mesh Render(Tree* t, const Region& r,
-                       uint32_t flags=Octree::COLLAPSE);
+    static Mesh Render(Tree* t, const Region& r);
 
     /*
      *  Saves the given mesh as a .stl file

--- a/kernel/include/ao/kernel/render/octree.hpp
+++ b/kernel/include/ao/kernel/render/octree.hpp
@@ -24,9 +24,8 @@ class Octree : public XTree<Octree, 3>
 {
 protected:
     Octree(const Subregion& r);
-    Octree(Evaluator* e, const Subregion& r, uint32_t flags);
-    Octree(Evaluator* e, const std::array<Octree*, 8>& cs,
-           const Subregion& r, uint32_t flags);
+    Octree(Evaluator* e, const Subregion& r);
+    Octree(Evaluator* e, const std::array<Octree*, 8>& cs, const Subregion& r);
 
     static const std::vector<bool>& cornerTable()
         { return _cornerTable; }

--- a/kernel/include/ao/kernel/render/quadtree.hpp
+++ b/kernel/include/ao/kernel/render/quadtree.hpp
@@ -23,9 +23,9 @@
 class Quadtree : public XTree<Quadtree, 2>
 {
     Quadtree(const Subregion& r);
-    Quadtree(Evaluator* e, const Subregion& r, uint32_t flags);
+    Quadtree(Evaluator* e, const Subregion& r);
     Quadtree(Evaluator* e, const std::array<Quadtree*, 4>& cs,
-           const Subregion& r, uint32_t flags);
+             const Subregion& r);
 
     static const std::vector<bool>& cornerTable()
         { return _cornerTable; }

--- a/kernel/include/ao/kernel/render/quadtree.hpp
+++ b/kernel/include/ao/kernel/render/quadtree.hpp
@@ -29,7 +29,7 @@ class Quadtree : public XTree<Quadtree, 2>
 
     static const std::vector<bool>& cornerTable()
         { return _cornerTable; }
-    const std::vector<std::pair<unsigned, unsigned>>& cellEdges()
+    static const std::vector<std::pair<unsigned, unsigned>>& cellEdges()
         { return _cellEdges; }
     bool leafTopology() const;
 

--- a/kernel/include/ao/kernel/render/region.hpp
+++ b/kernel/include/ao/kernel/render/region.hpp
@@ -31,11 +31,19 @@ class Region
 public:
     /*
      *  Constructs a region with the given bounds and res voxels per unit
+     *
+     *  If the bounds and resolution imply fractional voxels, the bounds are
+     *  expanded about their centers to include a unit number of voxels at the
+     *  specified resolution.
      */
     Region(Interval x, Interval y, Interval z, float res);
 
     /*
      *  Constructs a region with the given bounds and per-axis resolution
+     *
+     *  If the bounds and resolution imply fractional voxels, the bounds are
+     *  expanded about their centers to include a unit number of voxels at the
+     *  specified resolution.
      */
     Region(Interval x, Interval y, Interval z,
            float rx, float ry, float rz);
@@ -59,11 +67,17 @@ public:
      */
     struct Axis
     {
+        /* If i and res imply fractional values, the interval will be
+         * expanded to fit a whole number of voxels. */
         Axis(Interval i, float res);
         Axis(Interval i, size_t size);
 
         /*  Returns a pointer to the first value  */
         const float* ptr() const { return &values[0]; }
+
+        /*  Expands the input interval if it implies a fractional
+         *  voxel count */
+        static Interval expand(Interval i, float res);
 
         const Interval bounds;
         std::vector<float> values;

--- a/kernel/include/ao/kernel/render/xtree.hpp
+++ b/kernel/include/ao/kernel/render/xtree.hpp
@@ -85,12 +85,6 @@ public:
     Type getType() const { return type; }
 
     /*
-     *  Returns the vector of intersections
-     */
-    std::vector<Intersection> getIntersections() const
-    { return {}; }
-
-    /*
      *  Looks up the vertex position
      */
     glm::vec3 getVertex() const { return vert; }
@@ -132,8 +126,7 @@ protected:
     void finalize(Evaluator* e, uint32_t flags);
 
     /*
-     *  Stores edge-wise intersections for a LEAF cell,
-     *  storing them in the intersections vector.
+     *  Finds and returns edge-wise intersections for a LEAF cell
      *
      *  Intersections are found with binary search along every
      *  edge that exhibits a sign change.
@@ -238,7 +231,7 @@ protected:
     /*  Feature vertex located in the cell  */
     glm::vec3 vert=glm::vec3(std::numeric_limits<float>::quiet_NaN());
 
-    /*  Marks whether a LEAF node is manifold or not  */
+    /*  Marks whether a node is manifold or not  */
     bool manifold;
 
     /*  Mass point is the average intersection location *

--- a/kernel/include/ao/kernel/render/xtree.hpp
+++ b/kernel/include/ao/kernel/render/xtree.hpp
@@ -48,7 +48,6 @@ public:
 
     /*  Enumerator for optional flags  */
     enum Flags { COLLAPSE   = (1 << 0),
-                 NO_JITTER  = (1 << 1),
     };
 
     /*  Enumerator that distinguishes between cell types  */
@@ -101,10 +100,6 @@ public:
      */
     unsigned getLevel() const { return level; }
 
-    /*  This is the number of extra points added per intersection
-     *  if jittering is enabled */
-    const static unsigned JITTER_COUNT = 16;
-
 protected:
     /*
      *  Recursive constructor that splits r
@@ -119,10 +114,9 @@ protected:
     XTree(const std::array<T*, 1 << dims>& cs, const Subregion& r);
 
     /*
-     *  Delegating constructor to initialize X, Y, Z, and jitter
+     *  Delegating constructor to initialize X, Y, Z
      */
     XTree(const Subregion& r);
-    XTree(const Subregion& r, bool jitter);
 
     /*
      *  Splits a subregion and fills out child pointers and cell type
@@ -271,11 +265,6 @@ protected:
      *  This value is populated in find{Leaf|Branch}Matrices and     *
      *  used when merging intersections from lower-ranked children   */
     unsigned rank=0;
-
-    /*  If true, points found with searchEdge are jittered slightly to avoid
-     *  numerical instability when rendering shapes that lie exactly on cell
-     *  boundaries */
-    const bool jitter;
 
     /*  Number of iterations to run when doing binary search for verts  */
     const static int SEARCH_COUNT = 8;

--- a/kernel/include/ao/kernel/render/xtree.hpp
+++ b/kernel/include/ao/kernel/render/xtree.hpp
@@ -146,7 +146,7 @@ protected:
      *  Populates AtA, AtB, BtB, mass_point, and rank
      *  by calling findIntersections then building matrices
      */
-    void findLeafMatrices(Evaluator* e);
+    Eigen::EigenSolver<Eigen::Matrix3d> findLeafMatrices(Evaluator* e);
 
     /*
      *  Populates AtA, AtB, BtB, mass_point, and rank
@@ -171,6 +171,8 @@ protected:
      *  Returns the vertex and populates err if provided
      */
     glm::vec3 findVertex(float* err=NULL) const;
+    glm::vec3 findVertex(Eigen::EigenSolver<Eigen::Matrix3d>& es,
+                         float* err=NULL) const;
 
     /*
      *  Performs binary search along a cube's edge, returning the intersection

--- a/kernel/include/ao/kernel/render/xtree.hpp
+++ b/kernel/include/ao/kernel/render/xtree.hpp
@@ -142,6 +142,10 @@ protected:
      *  For leaf cells, intersections are found with binary search along every
      *  edge that exhibits a sign change.  For branch cells, intersections are
      *  found by accumulating from all child leaf cells with max rank.
+     *
+     *  This function also populated mass_point from the mean of intersections
+     *  (in a leaf node) or the sum of mass points from max-rank children (in
+     *  a branch node)
      */
     void findIntersections(Evaluator* eval);
 
@@ -168,6 +172,7 @@ protected:
 
     /*
      *  Performs binary search along a cube's edge and stores in intersections
+     *  Accumulates intersection position in mass_point
      *
      *  The resulting Intersections' normals are of unit length
      *
@@ -232,6 +237,10 @@ protected:
 
     /*  Feature vertex located in the cell  */
     glm::vec3 vert=glm::vec3(std::numeric_limits<float>::quiet_NaN());
+
+    /*  Mass point is the average intersection location *
+     *  (the w coordinate is number of points averaged) */
+    glm::vec4 mass_point=glm::vec4(0.0f, 0.0f, 0.0f, 0.0f);
 
     /*  Feature rank for the cell's vertex, where                    *
      *      1 is face, 2 is edge, 3 is corner                        *

--- a/kernel/include/ao/kernel/render/xtree.hpp
+++ b/kernel/include/ao/kernel/render/xtree.hpp
@@ -43,12 +43,7 @@ template <class T, int dims>
 class XTree
 {
 public:
-    static T* Render(Tree* t, const Region& r, uint32_t flags=COLLAPSE,
-                     bool multithread=true);
-
-    /*  Enumerator for optional flags  */
-    enum Flags { COLLAPSE   = (1 << 0),
-    };
+    static T* Render(Tree* t, const Region& r, bool multithread=true);
 
     /*  Enumerator that distinguishes between cell types  */
     enum Type { LEAF, BRANCH, EMPTY, FULL };
@@ -99,7 +94,7 @@ protected:
      *  Recursive constructor that splits r
      *  Requires a call to finalize in the parent constructor
      */
-    XTree(Evaluator* e, const Subregion& r, uint32_t flags);
+    XTree(Evaluator* e, const Subregion& r);
 
     /*
      *  Collecting constructor that assembles multiple subtrees
@@ -115,15 +110,14 @@ protected:
     /*
      *  Splits a subregion and fills out child pointers and cell type
      */
-    void populateChildren(Evaluator* e, const Subregion& r,
-                          uint32_t flags);
+    void populateChildren(Evaluator* e, const Subregion& r);
 
     /*
      *  Finishes initialization once the type and child pointers are in place
      *  (split into a separate function because we can get child pointers
      *   either through recursion or with threaded construction)
      */
-    void finalize(Evaluator* e, uint32_t flags);
+    void finalize(Evaluator* e);
 
     /*
      *  Finds and returns edge-wise intersections for a LEAF cell

--- a/kernel/include/ao/kernel/render/xtree.hpp
+++ b/kernel/include/ao/kernel/render/xtree.hpp
@@ -243,6 +243,9 @@ protected:
      *  (the w coordinate is number of points averaged) */
     glm::vec4 mass_point=glm::vec4(0.0f, 0.0f, 0.0f, 0.0f);
 
+    /*  Marks whether a LEAF node is manifold or not  */
+    bool manifold;
+
     /*  Feature rank for the cell's vertex, where                    *
      *      1 is face, 2 is edge, 3 is corner                        *
      *                                                               *

--- a/kernel/include/ao/kernel/render/xtree.hpp
+++ b/kernel/include/ao/kernel/render/xtree.hpp
@@ -159,8 +159,9 @@ protected:
 
     /*
      *  If all corners are of the same sign, convert to FULL or EMPTY
+     *  Returns true if the leaf was collapsed, false otherwise.
      */
-    void collapseLeaf();
+    bool collapseLeaf();
 
     /*
      *  Finds a feature vertex by finding intersections then solving a

--- a/kernel/include/ao/kernel/render/xtree.hpp
+++ b/kernel/include/ao/kernel/render/xtree.hpp
@@ -174,9 +174,9 @@ protected:
      *
      *  Requires AtA, AtB, BtB, and mass_point to be populated
      *
-     *  The resulting vertex is stored in vert; the residual is returned
+     *  Returns the vertex and populates err if provided
      */
-    float findVertex();
+    glm::vec3 findVertex(float* err=NULL) const;
 
     /*
      *  Performs binary search along a cube's edge, returning the intersection

--- a/kernel/include/ao/kernel/render/xtree.hpp
+++ b/kernel/include/ao/kernel/render/xtree.hpp
@@ -87,8 +87,8 @@ public:
     /*
      *  Returns the vector of intersections
      */
-    const std::vector<Intersection>& getIntersections() const
-    { return intersections; }
+    std::vector<Intersection> getIntersections() const
+    { return {}; }
 
     /*
      *  Looks up the vertex position
@@ -140,7 +140,7 @@ protected:
      *
      *  This function also populated mass_point as the mean of intersections.
      */
-    void findIntersections(Evaluator* e);
+    std::vector<Intersection> findIntersections(Evaluator* e);
 
     /*
      *  Populates AtA, AtB, BtB, mass_point, and rank
@@ -229,10 +229,6 @@ protected:
 
     /*  Cell type  */
     Type type;
-
-    /*  Intersections where the shape crosses the cell
-     *  Only populated for leaf cells */
-    std::vector<Intersection> intersections;
 
     /*  Pointers to children octrees (either all populated or all null)  */
     std::array<std::unique_ptr<T>, 1 << dims> children;

--- a/kernel/include/ao/kernel/render/xtree.hpp
+++ b/kernel/include/ao/kernel/render/xtree.hpp
@@ -163,12 +163,6 @@ protected:
     void collapseBranch();
 
     /*
-     *  If all corners are of the same sign, convert to FULL or EMPTY
-     *  Returns true if the leaf was collapsed, false otherwise.
-     */
-    bool collapseLeaf();
-
-    /*
      *  Finds a feature vertex by solving a least-squares fit to minimize
      *  a quadratic error function.
      *

--- a/kernel/include/ao/kernel/render/xtree.hpp
+++ b/kernel/include/ao/kernel/render/xtree.hpp
@@ -179,14 +179,13 @@ protected:
     float findVertex();
 
     /*
-     *  Performs binary search along a cube's edge and stores in intersections
-     *  Accumulates intersection position in mass_point
+     *  Performs binary search along a cube's edge, returning the intersection
      *
      *  The resulting Intersections' normals are of unit length
      *
      *  eval(a) should be < 0 (inside the shape) and eval(b) should be outside
      */
-    void searchEdge(glm::vec3 a, glm::vec3 b, Evaluator* eval);
+    Intersection searchEdge(glm::vec3 a, glm::vec3 b, Evaluator* eval);
 
     /*
      *  Checks to see if the cell's corners describe an ambiguous

--- a/kernel/include/ao/kernel/render/xtree.hpp
+++ b/kernel/include/ao/kernel/render/xtree.hpp
@@ -252,6 +252,9 @@ protected:
 
     /*  Number of iterations to run when doing binary search for verts  */
     const static int SEARCH_COUNT = 8;
+
+    /*  Eigenvalue threshold for determining feature rank  */
+    constexpr static float EIGENVALUE_CUTOFF = 0.1f;
 };
 
 #include "ao/kernel/render/xtree.ipp"

--- a/kernel/include/ao/kernel/render/xtree.hpp
+++ b/kernel/include/ao/kernel/render/xtree.hpp
@@ -140,7 +140,7 @@ protected:
      *
      *  This function also populated mass_point as the mean of intersections.
      */
-    std::vector<Intersection> findIntersections(Evaluator* e);
+    std::vector<Intersection> findIntersections(Evaluator* e) const;
 
     /*
      *  Populates AtA, AtB, BtB, mass_point, and rank

--- a/kernel/include/ao/kernel/render/xtree.hpp
+++ b/kernel/include/ao/kernel/render/xtree.hpp
@@ -185,7 +185,7 @@ protected:
      *
      *  eval(a) should be < 0 (inside the shape) and eval(b) should be outside
      */
-    Intersection searchEdge(glm::vec3 a, glm::vec3 b, Evaluator* eval);
+    Intersection searchEdge(glm::vec3 a, glm::vec3 b, Evaluator* eval) const;
 
     /*
      *  Checks to see if the cell's corners describe an ambiguous

--- a/kernel/include/ao/kernel/render/xtree.hpp
+++ b/kernel/include/ao/kernel/render/xtree.hpp
@@ -121,6 +121,7 @@ protected:
 
     /*
      *  Finds and returns edge-wise intersections for a LEAF cell
+     *  The intersections have normalized (length = 1) normals
      *
      *  Intersections are found with binary search along every
      *  edge that exhibits a sign change.
@@ -164,11 +165,9 @@ protected:
     /*
      *  Performs binary search along a cube's edge, returning the intersection
      *
-     *  The resulting Intersections' normals are of unit length
-     *
      *  eval(a) should be < 0 (inside the shape) and eval(b) should be outside
      */
-    Intersection searchEdge(glm::vec3 a, glm::vec3 b, Evaluator* eval) const;
+    glm::vec3 searchEdge(glm::vec3 a, glm::vec3 b, Evaluator* eval) const;
 
     /*
      *  Checks to see if the cell's corners describe an ambiguous

--- a/kernel/include/ao/kernel/render/xtree.ipp
+++ b/kernel/include/ao/kernel/render/xtree.ipp
@@ -379,7 +379,12 @@ glm::vec3 XTree<T, dims>::findVertex(
         D.diagonal()[i] = (std::abs(eigenvalues[i]) < 0.1)
             ? 0 : (1 / eigenvalues[i]);
     }
-    assert(D.diagonal().count() == rank);
+
+    // Sanity-checking that rank matches eigenvalue count
+    if (type == LEAF)
+    {
+        assert(D.diagonal().count() == rank);
+    }
 
     // SVD matrices
     auto U = es.eigenvectors().real(); // = V

--- a/kernel/include/ao/kernel/render/xtree.ipp
+++ b/kernel/include/ao/kernel/render/xtree.ipp
@@ -385,24 +385,17 @@ float XTree<T, dims>::findVertex()
     // We need to find the pseudo-inverse of AtA.
     Eigen::EigenSolver<Eigen::Matrix3d> es(AtA);
     auto eigenvalues = es.eigenvalues().real();
-    Eigen::Vector3d diag;
     double s_max = eigenvalues.cwiseAbs().maxCoeff();
 
-    // Truncate near-singular eigenvalues
+    // Truncate near-singular eigenvalues in the SVD's diagonal matrix
+    Eigen::Matrix3d D(Eigen::Matrix3d::Zero());
     for (unsigned i=0; i < 3; ++i)
     {
-        if (std::abs(eigenvalues[i]) / s_max < 0.1)
-        {
-            diag[i] = 0;
-        }
-        else
-        {
-            diag[i] = 1 / eigenvalues[i];
-        }
+        D.diagonal()[i] = (std::abs(eigenvalues[i]) / s_max < 0.1)
+            ? 0 : (1 / eigenvalues[i]);
     }
 
     // SVD matrices
-    auto D = diag.asDiagonal();
     auto U = es.eigenvectors().real(); // = V
 
     // Pseudo-inverse of A

--- a/kernel/include/ao/kernel/render/xtree.ipp
+++ b/kernel/include/ao/kernel/render/xtree.ipp
@@ -368,10 +368,6 @@ void XTree<T, dims>::findLeafMatrices(Evaluator* e)
 template <class T, int dims>
 float XTree<T, dims>::findVertex()
 {
-    // Find the center of intersection positions
-    glm::vec3 center = glm::vec3(mass_point.x, mass_point.y, mass_point.z) /
-                       mass_point.w;
-
     // For non-manifold leaf nodes, put the vertex at the mass point.
     // As described in "Dual Contouring: The Secret Sauce", this improves
     // mesh quality.
@@ -380,7 +376,8 @@ float XTree<T, dims>::findVertex()
         manifold = this->cornerTopology();
         if (!manifold)
         {
-            vert = center;
+            vert = glm::vec3(mass_point.x, mass_point.y, mass_point.z) /
+                   mass_point.w;
             return std::numeric_limits<float>::infinity();
         }
     }
@@ -412,13 +409,13 @@ float XTree<T, dims>::findVertex()
     auto AtAp = U.transpose() * D * U;
 
     // Solve for vertex (minimizing distance to center)
-    auto p = Eigen::Vector3d(center.x, center.y, center.z);
-    auto v = AtAp * (AtB - AtA * p);
-    auto vert_ = glm::vec3(v[0], v[1], v[2]) + center;
+    auto p = Eigen::Vector3d(mass_point.x, mass_point.y, mass_point.z) /
+             mass_point.w;
+    auto v = AtAp * (AtB - AtA * p) + p;
+    auto vert = glm::vec3(v[0], v[1], v[2]);
 
-    printf("%f %f %f\n", vert_[0], vert_[1], vert_[2]);
+    printf("%i: %f %f %f\n", rank, vert[0], vert[1], vert[2]);
 
-    vert = center;
     return std::numeric_limits<float>::infinity();
 
     /*

--- a/kernel/include/ao/kernel/render/xtree.ipp
+++ b/kernel/include/ao/kernel/render/xtree.ipp
@@ -112,41 +112,44 @@ void XTree<T, dims>::populateChildren(Evaluator* e, const Subregion& r,
         type = EMPTY;
     }
     // If the cell wasn't empty or filled, recurse
-    else if (r.canSplit())
-    {
-        e->push();
-        auto rs = r.splitEven(dims);
-        for (uint8_t i=0; i < children.size(); ++i)
-        {
-            // Populate child recursively
-            children[i].reset(new T(e, rs[i], flags));
-
-            // Grab corner values from children
-            corners[i] = children[i]->corners[i];
-        }
-        type = BRANCH;
-        e->pop();
-    }
-    // Otherwise, calculate corner values
     else
     {
-        // The cell is a LEAF cell until proven otherwise
-        type = LEAF;
-
-        // Pack into evaluator
-        for (uint8_t i=0; i < children.size(); ++i)
+        if (r.canSplit())
         {
-            auto c = pos(i);
-            e->set(c.x, c.y, c.z, i);
+            e->push();
+            auto rs = r.splitEven(dims);
+            for (uint8_t i=0; i < children.size(); ++i)
+            {
+                // Populate child recursively
+                children[i].reset(new T(e, rs[i], flags));
+
+                // Grab corner values from children
+                corners[i] = children[i]->corners[i];
+            }
+            type = BRANCH;
+            e->pop();
         }
-
-        // Do the evaluation
-        const float* fs = e->values(children.size());
-
-        // And unpack from evaluator
-        for (uint8_t i=0; i < children.size(); ++i)
+        // Otherwise, calculate corner values
+        else
         {
-            corners[i] = fs[i] < 0;
+            // The cell is a LEAF cell until proven otherwise
+            type = LEAF;
+
+            // Pack into evaluator
+            for (uint8_t i=0; i < children.size(); ++i)
+            {
+                auto c = pos(i);
+                e->set(c.x, c.y, c.z, i);
+            }
+
+            // Do the evaluation
+            const float* fs = e->values(children.size());
+
+            // And unpack from evaluator
+            for (uint8_t i=0; i < children.size(); ++i)
+            {
+                corners[i] = fs[i] < 0;
+            }
         }
     }
 

--- a/kernel/include/ao/kernel/render/xtree.ipp
+++ b/kernel/include/ao/kernel/render/xtree.ipp
@@ -199,20 +199,16 @@ void XTree<T, dims>::finalize(Evaluator* e, uint32_t flags)
         // Populate matrices, rank, and mass point
         findLeafMatrices(e);
 
-        // Find the vertex for this node
+        // Figure out if the leaf is manifold
         manifold = this->cornerTopology();
-        if (manifold)
-        {
-            vert = findVertex();
-        }
-        else
-        {
+
+        // Find the vertex for this node
+        vert = manifold ? findVertex() :
             // For non-manifold leaf nodes, put the vertex at the mass point.
             // As described in "Dual Contouring: The Secret Sauce", this improves
             // mesh quality.
             vert = glm::vec3(mass_point.x, mass_point.y, mass_point.z) /
                    mass_point.w;
-        }
     }
 
     // If this cell is no longer a branch, remove its children
@@ -229,8 +225,8 @@ std::vector<Intersection> XTree<T, dims>::findIntersections(
 {
     assert(type == LEAF);
 
-    // If this is a leaf cell, check every edge and use binary search to
-    // find intersections on edges that have mismatched signs
+    // Check every edge and use binary search to find intersections on
+    // edges that have mismatched signs
     std::vector<Intersection> intersections;
     for (auto e : static_cast<const T*>(this)->cellEdges())
     {
@@ -286,6 +282,7 @@ void XTree<T, dims>::collapseBranch()
                     [](const std::unique_ptr<T>& o)
                     { return o->manifold; }) &&
             static_cast<T*>(this)->leafTopology();
+
         if (manifold)
         {
             findBranchMatrices();

--- a/kernel/include/ao/kernel/render/xtree.ipp
+++ b/kernel/include/ao/kernel/render/xtree.ipp
@@ -116,6 +116,7 @@ void XTree<T, dims>::populateChildren(Evaluator* e, const Subregion& r,
             {
                 c = true;
             }
+            manifold = true;
         }
         else if (out.lower() >= 0)
         {
@@ -124,6 +125,7 @@ void XTree<T, dims>::populateChildren(Evaluator* e, const Subregion& r,
             {
                 c = false;
             }
+            manifold = true;
         }
         else
         {   // If the cell wasn't empty or filled, recurse
@@ -274,10 +276,12 @@ void XTree<T, dims>::collapseBranch()
     if (all_empty)
     {
         type = EMPTY;
+        manifold = true;
     }
     else if (all_full)
     {
         type = FULL;
+        manifold = true;
     }
     else if (collapsible)
     {
@@ -297,6 +301,7 @@ void XTree<T, dims>::collapseBranch()
             if (err < 1e-8)
             {
                 type = LEAF;
+                manifold = true;
             }
         }
     }

--- a/kernel/include/ao/kernel/render/xtree.ipp
+++ b/kernel/include/ao/kernel/render/xtree.ipp
@@ -208,7 +208,12 @@ void XTree<T, dims>::findIntersections(Evaluator* eval)
             Intersection i = (corner(e.first))
                 ? searchEdge(pos(e.first), pos(e.second), eval)
                 : searchEdge(pos(e.second), pos(e.first), eval);
+
+            // Store big list o' intersections
             intersections.push_back(i);
+
+            // Accumulate intersection in mass point
+            mass_point += glm::vec4(i.pos, 1.0f);
         }
     }
 }
@@ -417,7 +422,8 @@ bool XTree<T, dims>::cornerTopology() const
 }
 
 template<class T, int dims>
-Intersection XTree<T, dims>::searchEdge(glm::vec3 a, glm::vec3 b, Evaluator* e)
+Intersection XTree<T, dims>::searchEdge(glm::vec3 a, glm::vec3 b,
+                                        Evaluator* e) const
 {
     // We do an N-fold reduction at each stage
     constexpr int _N = 4;
@@ -446,9 +452,6 @@ Intersection XTree<T, dims>::searchEdge(glm::vec3 a, glm::vec3 b, Evaluator* e)
             }
         }
     }
-
-    // Accumulate intersection in mass point
-    mass_point += glm::vec4(a, 1.0f);
 
     // Get derivatives
     e->setRaw(a.x, a.y, a.z, 0);

--- a/kernel/include/ao/kernel/render/xtree.ipp
+++ b/kernel/include/ao/kernel/render/xtree.ipp
@@ -93,6 +93,7 @@ XTree<T, dims>::XTree(const std::array<T*, 1 << dims>& cs, const Subregion& r)
     for (uint8_t i=0; i < cs.size(); ++i)
     {
         children[i].reset(cs[i]);
+        corners[i] = children[i]->corners[i];
     }
     type = BRANCH;
 }

--- a/kernel/include/ao/kernel/render/xtree.ipp
+++ b/kernel/include/ao/kernel/render/xtree.ipp
@@ -451,23 +451,14 @@ void XTree<T, dims>::searchEdge(glm::vec3 a, glm::vec3 b, Evaluator* e)
         }
     }
 
-    // pos is an array of positions to get normals for
-    std::vector<glm::vec3> pos = {a};
+    // Accumulate intersection in mass point
+    mass_point += glm::vec4(a, 1.0f);
 
-    size_t count = 0;
-    for (auto p : pos)
-    {
-        e->setRaw(p.x, p.y, p.z, count++);
-        mass_point += glm::vec4(p.x, p.y, p.z, 1.0f);
-    }
+    // Get derivatives
+    e->setRaw(a.x, a.y, a.z, 0);
+    auto ds = e->derivs(1);
 
-    // Get set of derivative arrays
-    auto ds = e->derivs(count);
-
-    // Extract gradient from set of arrays
-    for (unsigned i=0; i < count; ++i)
-    {
-        glm::vec3 g(std::get<1>(ds)[i], std::get<2>(ds)[i], std::get<3>(ds)[i]);
-        intersections.push_back({pos[i], glm::normalize(g)});
-    }
+    // Extract gradient from normal arrays
+    glm::vec3 g(std::get<1>(ds)[0], std::get<2>(ds)[0], std::get<3>(ds)[0]);
+    intersections.push_back({a, glm::normalize(g)});
 }

--- a/kernel/include/ao/kernel/render/xtree.ipp
+++ b/kernel/include/ao/kernel/render/xtree.ipp
@@ -345,14 +345,7 @@ Eigen::EigenSolver<Eigen::Matrix3d> XTree<T, dims>::findLeafMatrices(Evaluator* 
     auto eigenvalues = es.eigenvalues().real();
 
     // Truncate near-singular eigenvalues
-    rank = 3;
-    for (unsigned i=0; i < 3; ++i)
-    {
-        if (std::abs(eigenvalues[i]) < 0.1)
-        {
-            rank--;
-        }
-    }
+    rank = (eigenvalues.array().abs() >= EIGENVALUE_CUTOFF).count();
 
     // Return the solver so it can be re-used
     return es;
@@ -377,7 +370,7 @@ glm::vec3 XTree<T, dims>::findVertex(
     Eigen::Matrix3d D(Eigen::Matrix3d::Zero());
     for (unsigned i=0; i < 3; ++i)
     {
-        D.diagonal()[i] = (std::abs(eigenvalues[i]) < 0.1)
+        D.diagonal()[i] = (std::abs(eigenvalues[i]) < EIGENVALUE_CUTOFF)
             ? 0 : (1 / eigenvalues[i]);
     }
 

--- a/kernel/include/ao/kernel/render/xtree.ipp
+++ b/kernel/include/ao/kernel/render/xtree.ipp
@@ -118,7 +118,11 @@ void XTree<T, dims>::populateChildren(Evaluator* e, const Subregion& r,
         auto rs = r.splitEven(dims);
         for (uint8_t i=0; i < children.size(); ++i)
         {
+            // Populate child recursively
             children[i].reset(new T(e, rs[i], flags));
+
+            // Grab corner values from children
+            corners[i] = children[i]->corners[i];
         }
         type = BRANCH;
         e->pop();
@@ -168,12 +172,6 @@ void XTree<T, dims>::finalize(Evaluator* e, uint32_t flags)
 
     if (type == BRANCH)
     {
-        // Grab corner values from children
-        for (uint8_t i=0; i < children.size(); ++i)
-        {
-            corners[i] = children[i]->corners[i];
-        }
-
         // Collapse branches if the COLLAPSE flag is set
         if (flags & COLLAPSE)
         {

--- a/kernel/include/ao/kernel/render/xtree.ipp
+++ b/kernel/include/ao/kernel/render/xtree.ipp
@@ -339,7 +339,8 @@ Eigen::EigenSolver<Eigen::Matrix3d> XTree<T, dims>::findLeafMatrices(Evaluator* 
     AtB = At * B;
     BtB = B.transpose() * B;
 
-    // Only find Eigenvalues (this is to calculate rank)
+    // Use eigenvalues to find rank, then return the solver
+    // (so it can be re-used to find vertex position)
     Eigen::EigenSolver<Eigen::Matrix3d> es(AtA);
     auto eigenvalues = es.eigenvalues().real();
 

--- a/kernel/include/ao/kernel/render/xtree.ipp
+++ b/kernel/include/ao/kernel/render/xtree.ipp
@@ -271,22 +271,26 @@ void XTree<T, dims>::findIntersections(Evaluator* eval)
 template <class T, int dims>
 void XTree<T, dims>::collapseBranch(Evaluator* e)
 {
-    // If all of the children are leafs, then collapse into a single LEAF cell
-    if (std::all_of(children.begin(), children.end(),
-            [](std::unique_ptr<T>& o){ return o->type == EMPTY; }))
+    bool all_empty = true;
+    bool all_full  = true;
+    bool collapsible = true;
+
+    for (const auto& c : children)
+    {
+        all_empty   &= c->type == EMPTY;
+        all_full    &= c->type == FULL;
+        collapsible &= c->type != BRANCH;
+    }
+
+    if (all_empty)
     {
         type = EMPTY;
     }
-    // If all of the children are full, then collapse into a single FULL cell
-    else if (std::all_of(children.begin(), children.end(),
-            [](std::unique_ptr<T>& o){ return o->type == FULL; }))
+    else if (all_full)
     {
         type = FULL;
     }
-    // If all of the children are non-branches, then check to see whether we
-    // can collapse into a single LEAF cell.
-    else if (std::all_of(children.begin(), children.end(),
-            [](std::unique_ptr<T>& o){ return o->type != BRANCH; }))
+    else if (collapsible)
     {
         //  This conditional implements the three checks described in
         //  [Ju et al, 2002] in the section titled

--- a/kernel/include/ao/kernel/render/xtree.ipp
+++ b/kernel/include/ao/kernel/render/xtree.ipp
@@ -72,32 +72,23 @@ T* XTree<T, dims>::Render(Tree* t, const Region& r, uint32_t flags,
 
 template <class T, int dims>
 XTree<T, dims>::XTree(const Subregion& r)
-    : XTree(r, false)
-{
-    // Nothing to do here (delegating constructor)
-}
-
-template <class T, int dims>
-XTree<T, dims>::XTree(const Subregion& r, bool jitter)
     : X(r.X.lower(), r.X.upper()),
       Y(r.Y.lower(), r.Y.upper()),
-      Z(r.Z.lower(), r.Z.upper()),
-      jitter(jitter)
-
+      Z(r.Z.lower(), r.Z.upper())
 {
     // Nothing to do here (delegating constructor)
 }
 
 template <class T, int dims>
 XTree<T, dims>::XTree(Evaluator* e, const Subregion& r, uint32_t flags)
-    : XTree(r, !(flags & NO_JITTER))
+    : XTree(r)
 {
     populateChildren(e, r, flags);
 }
 
 template <class T, int dims>
 XTree<T, dims>::XTree(const std::array<T*, 1 << dims>& cs, const Subregion& r)
-    : XTree(r, false)
+    : XTree(r)
 {
     for (uint8_t i=0; i < cs.size(); ++i)
     {
@@ -437,8 +428,6 @@ void XTree<T, dims>::searchEdge(glm::vec3 a, glm::vec3 b, Evaluator* e)
     constexpr int N = (1 << _N);
     constexpr int ITER = SEARCH_COUNT / _N;
 
-    const float len = glm::length(a - b);
-
     // Binary search for intersection
     for (int i=0; i < ITER; ++i)
     {
@@ -463,27 +452,7 @@ void XTree<T, dims>::searchEdge(glm::vec3 a, glm::vec3 b, Evaluator* e)
     }
 
     // pos is an array of positions to get normals for
-    // If jitter is disabled, it only contains the intersection
     std::vector<glm::vec3> pos = {a};
-
-    // If jitter is enabled, add a cloud of nearby points
-    if (jitter)
-    {
-        static_assert(JITTER_COUNT < Result::N, "JITTER_COUNT is too large");
-
-        const float r = len / 10.0f;
-        while (pos.size() < JITTER_COUNT)
-        {
-            if (dims == 3)
-            {
-                pos.push_back(a + glm::sphericalRand(r));
-            }
-            else if (dims == 2)
-            {
-                pos.push_back(a + glm::vec3(glm::circularRand(r), 0.0f));
-            }
-        }
-    }
 
     size_t count = 0;
     for (auto p : pos)

--- a/kernel/include/ao/kernel/render/xtree.ipp
+++ b/kernel/include/ao/kernel/render/xtree.ipp
@@ -399,7 +399,7 @@ float XTree<T, dims>::findVertex()
     auto U = es.eigenvectors().real(); // = V
 
     // Pseudo-inverse of A
-    auto AtAp = U.transpose() * D * U;
+    auto AtAp = U * D * U.transpose();
 
     // Solve for vertex (minimizing distance to center)
     auto p = Eigen::Vector3d(mass_point.x, mass_point.y, mass_point.z) /

--- a/kernel/include/ao/kernel/render/xtree.ipp
+++ b/kernel/include/ao/kernel/render/xtree.ipp
@@ -405,35 +405,12 @@ float XTree<T, dims>::findVertex()
     auto p = Eigen::Vector3d(mass_point.x, mass_point.y, mass_point.z) /
              mass_point.w;
     auto v = AtAp * (AtB - AtA * p) + p;
-    auto vert = glm::vec3(v[0], v[1], v[2]);
 
-    printf("%i: %f %f %f\n", rank, vert[0], vert[1], vert[2]);
+    // Convert out of Eigen's format and store
+    vert = glm::vec3(v[0], v[1], v[2]);
 
-    return std::numeric_limits<float>::infinity();
-
-    /*
-    // Use singular value decomposition to solve the least-squares fit.
-    Eigen::JacobiSVD<Eigen::MatrixX3f> svd(A, Eigen::ComputeFullU |
-                                              Eigen::ComputeFullV);
-
-    // Truncate singular values below 0.1
-    auto singular = svd.singularValues();
-    svd.setThreshold(0.1 / singular.maxCoeff());
-    rank = svd.rank();
-
-    // Solve the equation and convert back to cell coordinates
-    Eigen::Vector3f solution = svd.solve(B);
-    vert = glm::vec3(solution.x(), solution.y(), solution.z()) + center;
-
-    // Clamp vertex to be within the bounding box
-    vert.x = std::min(X.upper(), std::max(vert.x, X.lower()));
-    vert.y = std::min(Y.upper(), std::max(vert.y, Y.lower()));
-    vert.z = std::min(Z.upper(), std::max(vert.z, Z.lower()));
-
-    // Find and return QEF residual
-    auto m = A * solution - B;
-    return m.transpose() * m;
-    */
+    float err = (v.transpose() * AtA * v - 2*v.transpose() * AtB)[0] + BtB;
+    return err;
 }
 
 

--- a/kernel/include/ao/kernel/render/xtree.ipp
+++ b/kernel/include/ao/kernel/render/xtree.ipp
@@ -312,19 +312,17 @@ void XTree<T, dims>::collapseBranch(Evaluator* e)
 template <class T, int dims>
 bool XTree<T, dims>::collapseLeaf()
 {
-    if (std::all_of(corners.begin(), corners.end(),
-            [](bool c){ return !c; }))
+    bool filled = corners[0];
+    for (auto c : corners)
     {
-        type = EMPTY;
-        return true;
+        if (c != filled)
+        {
+            return false;
+        }
     }
-    else if (std::all_of(corners.begin(), corners.end(),
-            [](bool c){ return c; }))
-    {
-        type = FULL;
-        return true;
-    }
-    return false;
+
+    type = filled ? FULL : EMPTY;
+    return true;
 }
 
 template <class T, int dims>

--- a/kernel/include/ao/kernel/render/xtree.ipp
+++ b/kernel/include/ao/kernel/render/xtree.ipp
@@ -342,13 +342,12 @@ Eigen::EigenSolver<Eigen::Matrix3d> XTree<T, dims>::findLeafMatrices(Evaluator* 
     // Only find Eigenvalues (this is to calculate rank)
     Eigen::EigenSolver<Eigen::Matrix3d> es(AtA);
     auto eigenvalues = es.eigenvalues().real();
-    double s_max = eigenvalues.cwiseAbs().maxCoeff();
 
     // Truncate near-singular eigenvalues
     rank = 3;
     for (unsigned i=0; i < 3; ++i)
     {
-        if (std::abs(eigenvalues[i]) / s_max < 0.1)
+        if (std::abs(eigenvalues[i]) < 0.1)
         {
             rank--;
         }
@@ -372,15 +371,15 @@ glm::vec3 XTree<T, dims>::findVertex(
 {
     // We need to find the pseudo-inverse of AtA.
     auto eigenvalues = es.eigenvalues().real();
-    double s_max = eigenvalues.cwiseAbs().maxCoeff();
 
     // Truncate near-singular eigenvalues in the SVD's diagonal matrix
     Eigen::Matrix3d D(Eigen::Matrix3d::Zero());
     for (unsigned i=0; i < 3; ++i)
     {
-        D.diagonal()[i] = (std::abs(eigenvalues[i]) / s_max < 0.1)
+        D.diagonal()[i] = (std::abs(eigenvalues[i]) < 0.1)
             ? 0 : (1 / eigenvalues[i]);
     }
+    assert(D.diagonal().count() == rank);
 
     // SVD matrices
     auto U = es.eigenvectors().real(); // = V

--- a/kernel/include/ao/kernel/render/xtree.ipp
+++ b/kernel/include/ao/kernel/render/xtree.ipp
@@ -205,14 +205,10 @@ void XTree<T, dims>::findIntersections(Evaluator* eval)
     {
         if (corner(e.first) != corner(e.second))
         {
-            if (corner(e.first))
-            {
-                searchEdge(pos(e.first), pos(e.second), eval);
-            }
-            else
-            {
-                searchEdge(pos(e.second), pos(e.first), eval);
-            }
+            Intersection i = (corner(e.first))
+                ? searchEdge(pos(e.first), pos(e.second), eval)
+                : searchEdge(pos(e.second), pos(e.first), eval);
+            intersections.push_back(i);
         }
     }
 }
@@ -421,7 +417,7 @@ bool XTree<T, dims>::cornerTopology() const
 }
 
 template<class T, int dims>
-void XTree<T, dims>::searchEdge(glm::vec3 a, glm::vec3 b, Evaluator* e)
+Intersection XTree<T, dims>::searchEdge(glm::vec3 a, glm::vec3 b, Evaluator* e)
 {
     // We do an N-fold reduction at each stage
     constexpr int _N = 4;
@@ -460,5 +456,5 @@ void XTree<T, dims>::searchEdge(glm::vec3 a, glm::vec3 b, Evaluator* e)
 
     // Extract gradient from normal arrays
     glm::vec3 g(std::get<1>(ds)[0], std::get<2>(ds)[0], std::get<3>(ds)[0]);
-    intersections.push_back({a, glm::normalize(g)});
+    return {a, glm::normalize(g)};
 }

--- a/kernel/include/ao/kernel/render/xtree.ipp
+++ b/kernel/include/ao/kernel/render/xtree.ipp
@@ -256,6 +256,7 @@ void XTree<T, dims>::findIntersections(Evaluator* eval)
                         pts.push_back(n.pos);
                         intersections.push_back(n);
                     }
+                    mass_point += child(i)->mass_point;
                 }
             }
         }
@@ -324,10 +325,8 @@ float XTree<T, dims>::findVertex(Evaluator* e)
     findIntersections(e);
 
     // Find the center of intersection positions
-    glm::vec3 center = std::accumulate(
-            intersections.begin(), intersections.end(), glm::vec3(),
-            [](const glm::vec3& a, const Intersection& b)
-                { return a + b.pos; }) / float(intersections.size());
+    glm::vec3 center = glm::vec3(mass_point.x, mass_point.y, mass_point.z) /
+                       mass_point.w;
 
     /*  The A matrix is of the form
      *  [n1x, n1y, n1z]
@@ -433,7 +432,8 @@ void XTree<T, dims>::searchEdge(glm::vec3 a, glm::vec3 b, Evaluator* e)
         }
     }
 
-    // Calculate value and gradient at the given point
+    // pos is an array of positions to get normals for
+    // If jitter is disabled, it only contains the intersection
     std::vector<glm::vec3> pos = {a};
 
     // If jitter is enabled, add a cloud of nearby points
@@ -459,6 +459,7 @@ void XTree<T, dims>::searchEdge(glm::vec3 a, glm::vec3 b, Evaluator* e)
     for (auto p : pos)
     {
         e->setRaw(p.x, p.y, p.z, count++);
+        mass_point += glm::vec4(p.x, p.y, p.z, 1.0f);
     }
 
     // Get set of derivative arrays

--- a/kernel/include/ao/kernel/render/xtree.ipp
+++ b/kernel/include/ao/kernel/render/xtree.ipp
@@ -101,28 +101,15 @@ template <class T, int dims>
 void XTree<T, dims>::populateChildren(Evaluator* e, const Subregion& r,
                                       uint32_t flags)
 {
-    // The cell is a LEAF cell until proven otherwise
-    type = LEAF;
-
     // First, do interval evaluation to see if the cell should be checked
     Interval out = e->eval(r.X.bounds, r.Y.bounds, r.Z.bounds);
     if (out.upper() < 0)
     {
         type = FULL;
-        for (auto& c : corners)
-        {
-            c = true;
-        }
-        manifold = true;
     }
     else if (out.lower() >= 0)
     {
         type = EMPTY;
-        for (auto& c : corners)
-        {
-            c = false;
-        }
-        manifold = true;
     }
     // If the cell wasn't empty or filled, recurse
     else if (r.canSplit())
@@ -136,10 +123,12 @@ void XTree<T, dims>::populateChildren(Evaluator* e, const Subregion& r,
         type = BRANCH;
         e->pop();
     }
-
     // Otherwise, calculate corner values
-    if (type == LEAF)
+    else
     {
+        // The cell is a LEAF cell until proven otherwise
+        type = LEAF;
+
         // Pack into evaluator
         for (uint8_t i=0; i < children.size(); ++i)
         {
@@ -155,6 +144,15 @@ void XTree<T, dims>::populateChildren(Evaluator* e, const Subregion& r,
         {
             corners[i] = fs[i] < 0;
         }
+    }
+
+    if (type == FULL || type == EMPTY)
+    {
+        for (auto& c : corners)
+        {
+            c = type == FULL;
+        }
+        manifold = true;
     }
 }
 

--- a/kernel/include/ao/kernel/render/xtree.ipp
+++ b/kernel/include/ao/kernel/render/xtree.ipp
@@ -195,12 +195,13 @@ void XTree<T, dims>::finalize(Evaluator* e, uint32_t flags)
 }
 
 template <class T, int dims>
-void XTree<T, dims>::findIntersections(Evaluator* eval)
+std::vector<Intersection> XTree<T, dims>::findIntersections(Evaluator* eval)
 {
     assert(type == LEAF);
 
     // If this is a leaf cell, check every edge and use binary search to
     // find intersections on edges that have mismatched signs
+    std::vector<Intersection> intersections;
     for (auto e : static_cast<T*>(this)->cellEdges())
     {
         if (corner(e.first) != corner(e.second))
@@ -216,6 +217,8 @@ void XTree<T, dims>::findIntersections(Evaluator* eval)
             mass_point += glm::vec4(i.pos, 1.0f);
         }
     }
+
+    return intersections;
 }
 
 
@@ -309,7 +312,7 @@ bool XTree<T, dims>::collapseLeaf()
 template <class T, int dims>
 void XTree<T, dims>::findLeafMatrices(Evaluator* e)
 {
-    findIntersections(e);
+    std::vector<Intersection> intersections = findIntersections(e);
 
     /*  The A matrix is of the form
      *  [n1x, n1y, n1z]

--- a/kernel/include/ao/kernel/render/xtree.ipp
+++ b/kernel/include/ao/kernel/render/xtree.ipp
@@ -281,11 +281,12 @@ void XTree<T, dims>::collapseBranch()
         //  This conditional implements the three checks described in
         //  [Ju et al, 2002] in the section titled
         //      "Simplification with topology safety"
-        if (this->cornerTopology() &&
+        manifold = this->cornerTopology() &&
             std::all_of(children.begin(), children.end(),
                     [](const std::unique_ptr<T>& o)
                     { return o->manifold; }) &&
-            static_cast<T*>(this)->leafTopology())
+            static_cast<T*>(this)->leafTopology();
+        if (manifold)
         {
             findBranchMatrices();
 
@@ -294,7 +295,6 @@ void XTree<T, dims>::collapseBranch()
             if (err < 1e-8)
             {
                 type = LEAF;
-                manifold = true;
             }
         }
     }

--- a/kernel/src/render/dc.cpp
+++ b/kernel/src/render/dc.cpp
@@ -267,9 +267,9 @@ void Worker::quad(const Octree* a, const Octree* b,
 
 ////////////////////////////////////////////////////////////////////////////////
 
-Mesh Mesh::Render(Tree* t, const Region& r, uint32_t flags)
+Mesh Mesh::Render(Tree* t, const Region& r)
 {
-    std::unique_ptr<Octree> o(Octree::Render(t, r, flags));
+    std::unique_ptr<Octree> o(Octree::Render(t, r));
 
     DC::Worker w;
     w.cell(o.get());

--- a/kernel/src/render/dc2d.cpp
+++ b/kernel/src/render/dc2d.cpp
@@ -135,9 +135,9 @@ void Worker2D::segment(const Quadtree* a, const Quadtree* b)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-Contours Contours::Render(Tree* t, const Region& r, uint32_t flags)
+Contours Contours::Render(Tree* t, const Region& r)
 {
-    std::unique_ptr<Quadtree> q(Quadtree::Render(t, r, flags));
+    std::unique_ptr<Quadtree> q(Quadtree::Render(t, r));
 
     DC::Worker2D w;
     w.cell(q.get());

--- a/kernel/src/render/octree.cpp
+++ b/kernel/src/render/octree.cpp
@@ -27,17 +27,17 @@ Octree::Octree(const Subregion& r) : XTree(r)
     // Nothing to do here
 }
 
-Octree::Octree(Evaluator* e, const Subregion& r, uint32_t flags)
-    : XTree(e, r, flags)
+Octree::Octree(Evaluator* e, const Subregion& r)
+    : XTree(e, r)
 {
-    finalize(e, flags);
+    finalize(e);
 }
 
 Octree::Octree(Evaluator* e, const std::array<Octree*, 8>& cs,
-       const Subregion& r, uint32_t flags)
+       const Subregion& r)
     : XTree(cs, r)
 {
-    finalize(e, flags);
+    finalize(e);
 }
 
 // These are the twelve edges of an octree cell

--- a/kernel/src/render/quadtree.cpp
+++ b/kernel/src/render/quadtree.cpp
@@ -26,17 +26,17 @@ Quadtree::Quadtree(const Subregion& r) : XTree(r)
     // Nothing to do here
 }
 
-Quadtree::Quadtree(Evaluator* e, const Subregion& r, uint32_t flags)
-    : XTree(e, r, flags)
+Quadtree::Quadtree(Evaluator* e, const Subregion& r)
+    : XTree(e, r)
 {
-    finalize(e, flags);
+    finalize(e);
 }
 
 Quadtree::Quadtree(Evaluator* e, const std::array<Quadtree*, 4>& cs,
-       const Subregion& r, uint32_t flags)
+       const Subregion& r)
     : XTree(cs, r)
 {
-    finalize(e, flags);
+    finalize(e);
 }
 
 // These are the four edges of a quadtree cell

--- a/kernel/test/dc.cpp
+++ b/kernel/test/dc.cpp
@@ -89,7 +89,7 @@ TEST_CASE("Face normals")
         for (int i=0; i < 3; ++i)
         {
             Tree t(&s, s.operation(OP_ADD, axis[i], s.constant(0.75)));
-            auto m = Mesh::Render(&t, r, Octree::NO_JITTER);
+            auto m = Mesh::Render(&t, r);
             for (unsigned j=0; j < m.tris.size(); ++j)
             {
                 REQUIRE(m.norm(j) == norm[i]);
@@ -103,7 +103,7 @@ TEST_CASE("Face normals")
         {
             Tree t(&s, s.operation(OP_NEG,
                        s.operation(OP_ADD, axis[i], s.constant(0.75))));
-            auto m = Mesh::Render(&t, r, Octree::NO_JITTER);
+            auto m = Mesh::Render(&t, r);
             for (unsigned j=0; j < m.tris.size(); ++j)
             {
                 REQUIRE(m.norm(j) == -norm[i]);
@@ -154,7 +154,7 @@ TEST_CASE("2D contour tracking")
 
     Region r({-1, 1}, {-1, 1}, {0, 0}, 10);
 
-    auto m = Contours::Render(&t, r, Quadtree::NO_JITTER);
+    auto m = Contours::Render(&t, r);
     REQUIRE(m.contours.size() == 1);
 
     float min = 1;

--- a/kernel/test/dc.cpp
+++ b/kernel/test/dc.cpp
@@ -48,35 +48,6 @@ TEST_CASE("Small sphere mesh")
     REQUIRE(m.tris.size() == 12);
 }
 
-TEST_CASE("Face counts")
-{
-    Store s;
-
-    SECTION("Single level of recursion")
-    {
-        Region r({-1, 1}, {-1, 1}, {-1, 1}, 1);
-
-        for (Token* axis : {s.X(), s.Y(), s.Z()})
-        {
-            Tree t(&s, s.operation(OP_ADD, axis, s.constant(0.75)));
-            auto m = Mesh::Render(&t, r, 0);
-            REQUIRE(m.tris.size() == 2);
-        }
-    }
-
-    SECTION("Two levels of recursion")
-    {
-        Region r({-1, 1}, {-1, 1}, {-1, 1}, 2);
-
-        for (Token* axis : {s.X(), s.Y(), s.Z()})
-        {
-            Tree t(&s, s.operation(OP_ADD, axis, s.constant(0.75)));
-            auto m = Mesh::Render(&t, r, 0);
-            REQUIRE(m.tris.size() == 18);
-        }
-    }
-}
-
 TEST_CASE("Face normals")
 {
     Store s;
@@ -107,24 +78,6 @@ TEST_CASE("Face normals")
             for (unsigned j=0; j < m.tris.size(); ++j)
             {
                 REQUIRE(m.norm(j) == -norm[i]);
-            }
-        }
-    }
-
-    SECTION("Jittered")
-    {
-        for (int i=0; i < 3; ++i)
-        {
-            Tree t(&s, s.operation(OP_ADD, axis[i], s.constant(0.75)));
-            auto m = Mesh::Render(&t, r, 0);
-
-            for (unsigned j=0; j < m.tris.size(); ++j)
-            {
-                auto n = m.norm(j);
-                CAPTURE(glm::to_string(n));
-                CAPTURE(glm::to_string(norm[i]));
-                auto diff = glm::length(n - norm[i]);
-                REQUIRE(diff < 0.05);
             }
         }
     }

--- a/kernel/test/octree.cpp
+++ b/kernel/test/octree.cpp
@@ -78,27 +78,6 @@ TEST_CASE("Octree values")
     }
 }
 
-TEST_CASE("Octree intersections")
-{
-    Store s;
-    Tree t(&s, s.operation(OP_SUB, s.X(), s.constant(0.75)));
-    Region r({0, 1}, {0, 1}, {0, 1}, 1);
-
-    SECTION("Leaf")
-    {
-        std::unique_ptr<Octree> out(Octree::Render(&t, r));
-        REQUIRE(out->getType() == Octree::LEAF);
-
-        auto is = out->getIntersections();
-        REQUIRE(is.size() == 4);
-        for (auto i : is)
-        {
-            auto err = fabs(i.pos.x - 0.75);
-            REQUIRE(err < 0.125);
-        }
-    }
-}
-
 TEST_CASE("Vertex positioning")
 {
     Store s;

--- a/kernel/test/octree.cpp
+++ b/kernel/test/octree.cpp
@@ -86,25 +86,11 @@ TEST_CASE("Octree intersections")
 
     SECTION("Leaf")
     {
-        std::unique_ptr<Octree> out(Octree::Render(&t, r, Octree::NO_JITTER));
-        REQUIRE(out->getType() == Octree::LEAF);
-
-        auto is = out->getIntersections();
-        REQUIRE(is.size() == 4);
-        for (auto i : is)
-        {
-            auto err = fabs(i.pos.x - 0.75);
-            REQUIRE(err < 0.125);
-        }
-    }
-
-    SECTION("Jittered")
-    {
         std::unique_ptr<Octree> out(Octree::Render(&t, r));
         REQUIRE(out->getType() == Octree::LEAF);
 
         auto is = out->getIntersections();
-        REQUIRE(is.size() == 4 * Octree::JITTER_COUNT);
+        REQUIRE(is.size() == 4);
         for (auto i : is)
         {
             auto err = fabs(i.pos.x - 0.75);

--- a/kernel/test/region.cpp
+++ b/kernel/test/region.cpp
@@ -22,23 +22,50 @@
 
 TEST_CASE("Region::Axis construction")
 {
-    auto da = Region::Axis(Interval(0, 1), 1.0f);
-    REQUIRE(da.values.size() == 1);
+    SECTION("Exact values")
+    {
+        auto da = Region::Axis(Interval(0, 1), 1.0f);
+        REQUIRE(da.values.size() == 1);
 
-    auto db = Region::Axis(Interval(0, 1), 10.0f);
-    REQUIRE(db.values.size() == 10);
+        auto db = Region::Axis(Interval(0, 1), 10.0f);
+        REQUIRE(db.values.size() == 10);
 
-    auto dc = Region::Axis(Interval(0, 0), 1.0f);
-    REQUIRE(dc.values.size() == 1);
+        auto dc = Region::Axis(Interval(0, 0), 1.0f);
+        REQUIRE(dc.values.size() == 1);
+
+        auto dd = Region::Axis(Interval(-1, 1), 0.0f);
+        REQUIRE(dd.values.size() == 1);
+    }
+
+    SECTION("Expanding interval")
+    {
+        auto da = Region::Axis(Interval(0, 1.1), 1.0f);
+        REQUIRE(da.values.size() == 2);
+    }
 }
 
 TEST_CASE("Region::Axis values")
 {
-    auto da = Region::Axis(Interval(0, 1), 1.0f);
-    REQUIRE(da.values[0] == 0.5);
+    SECTION("Exact values");
+    {
+        auto da = Region::Axis(Interval(0, 1), 1.0f);
+        REQUIRE(da.values[0] == 0.5);
 
-    auto db = Region::Axis(Interval(-0.5, 0.5), 3.0f);
-    REQUIRE(db.values[1] == 0);
+        auto db = Region::Axis(Interval(-0.5, 0.5), 3.0f);
+        REQUIRE(db.values[1] == 0);
+
+        auto dc = Region::Axis(Interval(-1, 1), 0.0f);
+        REQUIRE(dc.values[0] == 0);
+    }
+
+    SECTION("Expanding interval")
+    {
+        auto da = Region::Axis(Interval(0, 1.2), 1.0f);
+        REQUIRE(da.bounds.lower() == Approx(-0.4f));
+        REQUIRE(da.bounds.upper() == Approx(1.6f));
+        REQUIRE(da.values[0] == Approx(0.1f));
+        REQUIRE(da.values[1] == Approx(1.1f));
+    }
 }
 
 TEST_CASE("Region resolution")


### PR DESCRIPTION
This PR dramatically improves meshing performance and quality.

It's based on a close reading of [Dual Contouring: The Secret Sauce](https://people.eecs.berkeley.edu/~jrs/meshpapers/SchaeferWarren2.pdf) and implements everything but the QR triangular form (choosing instead to use doubles over floats, since RAM is cheap).

The PR also removes the `XTree` flags for `COLLAPSE` (because there was no good use case for it) and `JITTER` (because the more numerically stable algorithm made it unnecessary; also because it was a bad idea to begin with).