### PR TITLE
Longlived evaluator

### DIFF
--- a/kernel/include/ao/kernel/eval/evaluator.hpp
+++ b/kernel/include/ao/kernel/eval/evaluator.hpp
@@ -122,10 +122,16 @@ public:
      */
     double utilization() const;
 
+    /*
+     *  Sets the global matrix transform
+     *  Invalidates all positions and results
+     */
+    void setMatrix(const glm::mat4& m);
+
 protected:
     /*  Global matrix transform (and inverse) applied to all coordinates  */
-    const glm::mat4 M;
-    const glm::mat4 Mi;
+    glm::mat4 M;
+    glm::mat4 Mi;
 
     /*  Indices of X, Y, Z coordinates */
     uint32_t X, Y, Z;

--- a/kernel/include/ao/kernel/render/heightmap.hpp
+++ b/kernel/include/ao/kernel/render/heightmap.hpp
@@ -26,6 +26,8 @@
 #include "ao/kernel/format/image.hpp"
 #include "ao/kernel/tree/tree.hpp"
 
+class Evaluator;
+
 namespace Heightmap
 {
 
@@ -37,4 +39,9 @@ namespace Heightmap
 std::pair<DepthImage, NormalImage> Render(
         const Tree t, Region r, const std::atomic_bool& abort,
         glm::mat4 m=glm::mat4(), size_t threads=8);
+
+std::pair<DepthImage, NormalImage> Render(
+        const std::vector<Evaluator*>& es, Region r,
+        const std::atomic_bool& abort,
+        glm::mat4 m=glm::mat4());
 }

--- a/kernel/src/eval/evaluator.cpp
+++ b/kernel/src/eval/evaluator.cpp
@@ -30,8 +30,9 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 Evaluator::Evaluator(const Tree root_, const glm::mat4& M)
-    : M(M), Mi(glm::inverse(M))
 {
+    setMatrix(M);
+
     auto root = root_.collapse();
     Cache* cache = root.parent.get();
     auto connected = cache->findConnected(root.id);
@@ -1114,4 +1115,10 @@ void Evaluator::applyTransform(Result::Index count)
 double Evaluator::utilization() const
 {
     return tape->size() / double(tapes.front().size());
+}
+
+void Evaluator::setMatrix(const glm::mat4& m)
+{
+    M = m;
+    Mi = glm::inverse(m);
 }

--- a/ui/include/ao/ui/gl/frame.hpp
+++ b/ui/include/ao/ui/gl/frame.hpp
@@ -33,11 +33,6 @@
 class Frame
 {
 public:
-    /*
-     *  Constructor and destructor
-     *
-     *  On construction, takes ownership of the given Tree
-     */
     explicit Frame(const Tree root);
     ~Frame();
 
@@ -70,7 +65,6 @@ protected:
      */
     void startRender();
 
-    const Tree tree;
     std::vector<Evaluator*> evaluators;
 
     GLuint vs;  // Vertex shader

--- a/ui/include/ao/ui/gl/frame.hpp
+++ b/ui/include/ao/ui/gl/frame.hpp
@@ -36,8 +36,7 @@ public:
     /*
      *  Constructor and destructor
      *
-     *  On construction, takes ownership of the given Tree and sets
-     *  its parent pointer.
+     *  On construction, takes ownership of the given Tree
      */
     explicit Frame(const Tree root);
     ~Frame();
@@ -72,6 +71,7 @@ protected:
     void startRender();
 
     const Tree tree;
+    std::vector<Evaluator*> evaluators;
 
     GLuint vs;  // Vertex shader
     GLuint fs;  // Fragment shader

--- a/ui/include/ao/ui/worker.hpp
+++ b/ui/include/ao/ui/worker.hpp
@@ -16,6 +16,8 @@
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with Ao.  If not, see <http://www.gnu.org/licenses/>.
  */
+#pragma once
+
 #include <chrono>
 #include <future>
 

--- a/ui/include/ao/ui/worker.hpp
+++ b/ui/include/ao/ui/worker.hpp
@@ -39,7 +39,7 @@ struct Worker
      *
      *  depth and norm are target textures in which results are stored
      */
-    Worker(const Tree root, const Task& task);
+    Worker(const std::vector<Evaluator*>& evaluators, const Task& task);
 
     /*
      *  On destruction, join the thread

--- a/ui/src/gl/frame.cpp
+++ b/ui/src/gl/frame.cpp
@@ -89,8 +89,7 @@ void main()
 ////////////////////////////////////////////////////////////////////////////////
 
 Frame::Frame(const Tree root)
-    : tree(root.collapse()),
-      vs(Shader::compile(vert, GL_VERTEX_SHADER)),
+    : vs(Shader::compile(vert, GL_VERTEX_SHADER)),
       fs(Shader::compile(frag, GL_FRAGMENT_SHADER)),
       prog(Shader::link(vs, fs))
 {
@@ -119,6 +118,7 @@ Frame::Frame(const Tree root)
     }
     glBindVertexArray(0);
 
+    auto tree = root.collapse();
     for (unsigned i=0; i < 8; ++i)
     {
         evaluators.push_back(new Evaluator(tree));
@@ -207,7 +207,7 @@ void Frame::startRender()
     {
         // Swap around render tasks and start an async worker
         pending = next;
-        worker.reset(new Worker(tree, pending));
+        worker.reset(new Worker(evaluators, pending));
         next.reset();
     }
     // Schedule a refinement of the current render task

--- a/ui/src/gl/frame.cpp
+++ b/ui/src/gl/frame.cpp
@@ -24,8 +24,7 @@
 
 #include "ao/ui/worker.hpp"
 
-#include "ao/kernel/render/heightmap.hpp"
-#include "ao/kernel/render/region.hpp"
+#include "ao/kernel/eval/evaluator.hpp"
 
 ////////////////////////////////////////////////////////////////////////////////
 // Vertex shader
@@ -119,6 +118,11 @@ Frame::Frame(const Tree root)
         glEnableVertexAttribArray(0);
     }
     glBindVertexArray(0);
+
+    for (unsigned i=0; i < 8; ++i)
+    {
+        evaluators.push_back(new Evaluator(tree));
+    }
 }
 
 Frame::~Frame()
@@ -131,6 +135,11 @@ Frame::~Frame()
     glDeleteTextures(2, norm);
     glDeleteBuffers(1, &vbo);
     glDeleteVertexArrays(1, &vao);
+
+    for (auto e : evaluators)
+    {
+        delete e;
+    }
 }
 
 void Frame::draw(const glm::mat4& m) const

--- a/ui/src/worker.cpp
+++ b/ui/src/worker.cpp
@@ -26,7 +26,7 @@
 
 #include "ao/kernel/eval/evaluator.hpp"
 
-Worker::Worker(const Tree root, const Task& t)
+Worker::Worker(const std::vector<Evaluator*>& evaluators, const Task& t)
     : region({-1, 1}, {-1, 1}, {-1, 1},
              t.ni/(1 << t.level), t.nj/(1 << t.level), t.nk/(1 << t.level)),
       future(promise.get_future()), abort(false)
@@ -39,7 +39,7 @@ Worker::Worker(const Tree root, const Task& t)
 
     thread = std::thread([=](){
         auto start_time = std::chrono::system_clock::now();
-        auto out = Heightmap::Render(root, this->region, this->abort, m);
+        auto out = Heightmap::Render(evaluators, this->region, this->abort, m);
 
         // Map the depth buffer into the 0 - 1 range, with -inf = 1
         Eigen::ArrayXXf d =


### PR DESCRIPTION
This makes the UI faster by saving and re-using `Evaluator` objects for a given `Tree` (rather than reconstructing them whenever the rotation matrix changed).