### PR TITLE
Add variables and gradient calculation

### DIFF
--- a/kernel/include/ao/kernel/eval/evaluator.hpp
+++ b/kernel/include/ao/kernel/eval/evaluator.hpp
@@ -73,7 +73,7 @@ public:
     /*
      *  Returns the gradient with respect to all VARs
      */
-    std::map<Cache::Id, float> gradient();
+    std::map<Cache::Id, float> gradient(float x, float y, float z);
 
     /*
      *  Evaluates a single interval (stored with set)
@@ -133,6 +133,11 @@ public:
      */
     void setMatrix(const glm::mat4& m);
 
+    /*
+     *  Changes a variable's value
+     */
+    void setVar(Cache::Id var, float value);
+
 protected:
     /*  Global matrix transform (and inverse) applied to all coordinates  */
     glm::mat4 M;
@@ -144,7 +149,7 @@ protected:
     /*  Map of variables (in terms of where they live in this Evaluator) to
      *  their ids in their respective Tree (e.g. what you get when calling
      *  Tree::var(3.0).var() */
-    std::map<Clause::Id, Cache::Id> vars;
+    boost::bimap<Clause::Id, Cache::Id> vars;
 
     /*  Tape containing our opcodes in reverse order */
     typedef std::vector<Clause> Tape;

--- a/kernel/include/ao/kernel/eval/evaluator.hpp
+++ b/kernel/include/ao/kernel/eval/evaluator.hpp
@@ -73,7 +73,7 @@ public:
     /*
      *  Returns the gradient with respect to all VARs
      */
-    const std::vector<float>& gradient();
+    std::map<Cache::Id, float> gradient();
 
     /*
      *  Evaluates a single interval (stored with set)
@@ -141,8 +141,10 @@ protected:
     /*  Indices of X, Y, Z coordinates */
     Clause::Id X, Y, Z;
 
-    /*  Indices of other variables in the results array  */
-    std::vector<Clause::Id> vars;
+    /*  Map of variables (in terms of where they live in this Evaluator) to
+     *  their ids in their respective Tree (e.g. what you get when calling
+     *  Tree::var(3.0).var() */
+    std::map<Clause::Id, Cache::Id> vars;
 
     /*  Tape containing our opcodes in reverse order */
     typedef std::vector<Clause> Tape;

--- a/kernel/include/ao/kernel/eval/evaluator.hpp
+++ b/kernel/include/ao/kernel/eval/evaluator.hpp
@@ -71,6 +71,11 @@ public:
 #endif
 
     /*
+     *  Returns the gradient with respect to all VARs
+     */
+    const std::vector<float>& gradient();
+
+    /*
      *  Evaluates a single interval (stored with set)
      */
     Interval interval();

--- a/kernel/include/ao/kernel/eval/evaluator.hpp
+++ b/kernel/include/ao/kernel/eval/evaluator.hpp
@@ -134,7 +134,10 @@ protected:
     glm::mat4 Mi;
 
     /*  Indices of X, Y, Z coordinates */
-    uint32_t X, Y, Z;
+    Clause::Id X, Y, Z;
+
+    /*  Indices of other variables in the results array  */
+    std::vector<Clause::Id> vars;
 
     /*  Tape containing our opcodes in reverse order */
     typedef std::vector<Clause> Tape;

--- a/kernel/include/ao/kernel/eval/result.hpp
+++ b/kernel/include/ao/kernel/eval/result.hpp
@@ -39,7 +39,7 @@ struct Result {
      *  (across the Interval, and float / __m256 arrays)
      *
      *  Gradients are set to {0, 0, 0}
-     *  Jacobian is set to 0
+     *  Gradient is set to 0
      */
     void fill(float v, Index clause);
 
@@ -52,7 +52,7 @@ struct Result {
     /*
      *  Marks that j[clause][var] = 1
      */
-    void setJacobian(Index clause, Index var);
+    void setGradient(Index clause, Index var);
 
     /*
      *  Fills the derivative arrays with the given values
@@ -80,7 +80,7 @@ struct Result {
     std::vector<std::array<float, N>> dy;
     std::vector<std::array<float, N>> dz;
 #endif
-    /*  mj[clause][var] = dclause / dvar */
+    /*  j[clause][var] = dclause / dvar */
     std::vector<std::vector<float>> j;
 
     std::vector<Interval> i;

--- a/kernel/include/ao/kernel/eval/result.hpp
+++ b/kernel/include/ao/kernel/eval/result.hpp
@@ -36,12 +36,18 @@ struct Result {
 
     /*
      *  Sets all of the values to the given constant float
-     *  (across the Interval, float, Gradient, and __m256 arrays)
+     *  (across the Interval, and float / __m256 arrays)
      *
      *  Gradients are set to {0, 0, 0}
      *  Jacobian is set to 0
      */
     void fill(float v, Index clause);
+
+    /*
+     *  Sets all of the values to the given constant float
+     *  (across the Interval, and float / __m256 arrays)
+     */
+    void setValue(float v, Index clause);
 
     /*
      *  Marks that j[clause][var] = 1

--- a/kernel/include/ao/kernel/eval/result.hpp
+++ b/kernel/include/ao/kernel/eval/result.hpp
@@ -27,25 +27,31 @@
 #include "ao/kernel/eval/clause.hpp"
 
 struct Result {
-    typedef uint32_t Index;
+    typedef Clause::Id Index;
 
     /*
      *  Prepares the given number of clauses
      */
-    void resize(Clause::Id clauses);
+    void resize(Index clauses, Index vars=0);
 
     /*
      *  Sets all of the values to the given constant float
      *  (across the Interval, float, Gradient, and __m256 arrays)
      *
      *  Gradients are set to {0, 0, 0}
+     *  Jacobian is set to 0
      */
-    void fill(float v, Clause::Id clause);
+    void fill(float v, Index clause);
+
+    /*
+     *  Marks that j[clause][var] = 1
+     */
+    void setJacobian(Index clause, Index var);
 
     /*
      *  Fills the derivative arrays with the given values
      */
-    void deriv(float x, float y, float z, Clause::Id clause);
+    void deriv(float x, float y, float z, Index clause);
 
     // This is the number of samples that we can process in one pass
     static constexpr Index N = 256;
@@ -68,5 +74,8 @@ struct Result {
     std::vector<std::array<float, N>> dy;
     std::vector<std::array<float, N>> dz;
 #endif
+    /*  mj[clause][var] = dclause / dvar */
+    std::vector<std::vector<float>> j;
+
     std::vector<Interval> i;
 };

--- a/kernel/include/ao/kernel/tree/cache.hpp
+++ b/kernel/include/ao/kernel/tree/cache.hpp
@@ -161,6 +161,7 @@ protected:
         size_t rank() const             { return std::get<0>(*this); }
         Opcode::Opcode opcode() const   { return std::get<1>(*this); }
         Id lhs() const                  { return std::get<2>(*this); }
+        Id var() const                  { return lhs(); }
         Id rhs() const                  { return std::get<3>(*this); }
         float value() const             { return std::get<4>(*this); }
     };

--- a/kernel/include/ao/kernel/tree/cache.hpp
+++ b/kernel/include/ao/kernel/tree/cache.hpp
@@ -64,6 +64,11 @@ public:
      */
     Id operation(Opcode::Opcode op, Id a=0, Id b=0, bool collapse=true);
 
+    /*
+     *  Returns a new variable node with the given value
+     */
+    Id var(float v);
+
     Id X() { return operation(Opcode::VAR_X); }
     Id Y() { return operation(Opcode::VAR_Y); }
     Id Z() { return operation(Opcode::VAR_Z); }
@@ -150,6 +155,8 @@ protected:
           : _Key(0, Opcode::CONST, 0, 0, v) { /* Nothing to do here */ }
         Key(Opcode::Opcode op, Id a, Id b, size_t rank)
           : _Key(rank, op, a, b, 0.0f) { /* Nothing to do here */}
+        Key(float v, Id id)
+          : _Key(0, Opcode::VAR, id, 0, v) { /* Nothing to do here */}
 
         size_t rank() const             { return std::get<0>(*this); }
         Opcode::Opcode opcode() const   { return std::get<1>(*this); }

--- a/kernel/include/ao/kernel/tree/opcode.hpp
+++ b/kernel/include/ao/kernel/tree/opcode.hpp
@@ -31,6 +31,7 @@ enum Opcode
     VAR_X,
     VAR_Y,
     VAR_Z,
+    VAR,
 
     SQUARE,
     SQRT,

--- a/kernel/include/ao/kernel/tree/tree.hpp
+++ b/kernel/include/ao/kernel/tree/tree.hpp
@@ -90,6 +90,7 @@ public:
     Tree rhs() const                { return Tree(parent, parent->rhs(id)); }
     size_t rank() const             { return parent->rank(id); }
     float value() const             { return parent->value(id); }
+    size_t var() const              { return parent->lhs(id); }
 
 protected:
     /*

--- a/kernel/include/ao/kernel/tree/tree.hpp
+++ b/kernel/include/ao/kernel/tree/tree.hpp
@@ -66,6 +66,11 @@ public:
     static Tree affine(float a, float b, float c, float d);
 
     /*
+     *  Returns a new variable with the given value
+     */
+    static Tree var(float v);
+
+    /*
      *  Returns a new Tree that is a flattened copy of this tree
      */
     Tree collapse() const;

--- a/kernel/src/eval/evaluator.cpp
+++ b/kernel/src/eval/evaluator.cpp
@@ -104,7 +104,7 @@ Evaluator::Evaluator(const Tree root_, const glm::mat4& M)
     }
 
     // Allocate enough memory for all the clauses
-    result.resize(clauses.size());
+    result.resize(clauses.size(), vars.size());
     disabled.resize(clauses.size());
 
     // Store all constants in results array

--- a/kernel/src/eval/evaluator.cpp
+++ b/kernel/src/eval/evaluator.cpp
@@ -1284,6 +1284,21 @@ std::tuple<const float*, const float*,
     };
 }
 
+const std::vector<float>& Evaluator::gradient()
+{
+    for (auto itr = tape->rbegin(); itr != tape->rend(); ++itr)
+    {
+        const float* av = result.f[itr->a];
+        const float* bv = result.f[itr->b];
+        std::vector<float>& aj = result.j[itr->a];
+        std::vector<float>& bj = result.j[itr->b];
+
+         eval_clause_jacobians(itr->op, av, aj, bv, bj,
+            result.f[itr->id], result.j[itr->id]);
+    }
+    return result.j[0];
+}
+
 Interval Evaluator::interval()
 {
     for (auto itr = tape->rbegin(); itr != tape->rend(); ++itr)

--- a/kernel/src/eval/evaluator.cpp
+++ b/kernel/src/eval/evaluator.cpp
@@ -113,14 +113,23 @@ Evaluator::Evaluator(const Tree root_, const glm::mat4& M)
         result.fill(c.second, c.first);
     }
 
-    // Save X, Y, Z ids and set their derivatives
+    // Save X, Y, Z ids
     X = clauses.at(cache->X());
     Y = clauses.at(cache->Y());
     Z = clauses.at(cache->Z());
 
+    // Set derivatives for X, Y, Z (unchanging)
     result.deriv(1, 0, 0, X);
     result.deriv(0, 1, 0, Y);
     result.deriv(0, 0, 1, Z);
+
+    {   // Set the Jacobian for our variables (unchanging)
+        size_t index = 0;
+        for (auto v : vars)
+        {
+            result.setJacobian(v, index++);
+        }
+    }
 
     assert(clauses.at(root.id) == 0);
 }

--- a/kernel/src/eval/evaluator.cpp
+++ b/kernel/src/eval/evaluator.cpp
@@ -68,9 +68,16 @@ Evaluator::Evaluator(const Tree root_, const glm::mat4& M)
             // Other clauses get allocated results but no tape
             else
             {
+                // For constants and variables, record their values so
+                // that we can store those values in the result array
                 if (m.first.opcode() == Opcode::CONST)
                 {
                     constants[id] = m.first.value();
+                }
+                else if (m.first.opcode() == Opcode::VAR)
+                {
+                    constants[id] = m.first.value();
+                    vars.push_back(id);
                 }
                 clauses[m.second] = id--;
             }
@@ -334,6 +341,7 @@ static void clause(Opcode::Opcode op,
         case Opcode::VAR_X:
         case Opcode::VAR_Y:
         case Opcode::VAR_Z:
+        case Opcode::VAR:
         case Opcode::AFFINE_VEC:
         case Opcode::LAST_OP: assert(false);
     }
@@ -607,6 +615,7 @@ static void clause(Opcode::Opcode op,
         case Opcode::VAR_X:
         case Opcode::VAR_Y:
         case Opcode::VAR_Z:
+        case Opcode::VAR:
         case Opcode::AFFINE_VEC:
         case Opcode::LAST_OP: assert(false);
     }
@@ -693,6 +702,7 @@ static void clause(Opcode::Opcode op,
         case Opcode::VAR_X:
         case Opcode::VAR_Y:
         case Opcode::VAR_Z:
+        case Opcode::VAR:
         case Opcode::AFFINE_VEC:
         case Opcode::LAST_OP: assert(false);
     }
@@ -881,6 +891,7 @@ static void clause(Opcode::Opcode op,
         case Opcode::VAR_X:
         case Opcode::VAR_Y:
         case Opcode::VAR_Z:
+        case Opcode::VAR:
         case Opcode::AFFINE_VEC:
         case Opcode::LAST_OP: assert(false);
     }
@@ -945,6 +956,7 @@ static Interval clause(Opcode::Opcode op, const Interval& a, const Interval& b)
         case Opcode::VAR_X:
         case Opcode::VAR_Y:
         case Opcode::VAR_Z:
+        case Opcode::VAR:
         case Opcode::AFFINE_VEC:
         case Opcode::LAST_OP: assert(false);
     }

--- a/kernel/src/eval/evaluator.cpp
+++ b/kernel/src/eval/evaluator.cpp
@@ -127,7 +127,7 @@ Evaluator::Evaluator(const Tree root_, const glm::mat4& M)
         size_t index = 0;
         for (auto v : vars.left)
         {
-            result.setJacobian(v.first, index++);
+            result.setGradient(v.first, index++);
         }
     }
 

--- a/kernel/src/eval/result.cpp
+++ b/kernel/src/eval/result.cpp
@@ -48,7 +48,7 @@ void Result::fill(float v, Index clause)
 {
     setValue(v, clause);
 
-    // Fill the Jacobian row with zeros
+    // Fill the Gradient row with zeros
     for (auto& d : j[clause])
     {
         d = 0;
@@ -68,7 +68,7 @@ void Result::setValue(float v, Index clause)
     i[clause] = Interval(v, v);
 }
 
-void Result::setJacobian(Index clause, Index var)
+void Result::setGradient(Index clause, Index var)
 {
     // Drop a 1 in the Jacobian row at the var index
     j[clause][var] = 1;

--- a/kernel/src/eval/result.cpp
+++ b/kernel/src/eval/result.cpp
@@ -18,14 +18,13 @@
  */
 #include "ao/kernel/eval/result.hpp"
 
-void Result::resize(Index clauses)
+void Result::resize(Index clauses, Index vars)
 {
 #ifdef __AVX__
     mf.resize(clauses);
     mdx.resize(clauses);
     mdy.resize(clauses);
     mdz.resize(clauses);
-    i.resize(clauses);
 
     f  = reinterpret_cast<float(*)[N]>(&mf[0]);
     dx = reinterpret_cast<float(*)[N]>(&mdx[0]);
@@ -37,9 +36,15 @@ void Result::resize(Index clauses)
     dy.resize(clauses);
     dz.resize(clauses);
 #endif
+    i.resize(clauses);
+    j.resize(clauses);
+    for (auto& d : j)
+    {
+        d.resize(vars);
+    }
 }
 
-void Result::fill(float v, Clause::Id clause)
+void Result::fill(float v, Index clause)
 {
     for (unsigned i=0; i < N; ++i)
     {
@@ -50,9 +55,21 @@ void Result::fill(float v, Clause::Id clause)
     }
 
     i[clause] = Interval(v, v);
+
+    // Fill the Jacobian row with zeros
+    for (auto& d : j[clause])
+    {
+        d = 0;
+    }
 }
 
-void Result::deriv(float x, float y, float z, Clause::Id clause)
+void Result::setJacobian(Index clause, Index var)
+{
+    // Drop a 1 in the Jacobian row at the var index
+    j[clause][var] = 1;
+}
+
+void Result::deriv(float x, float y, float z, Index clause)
 {
     for (size_t i=0; i < N; ++i)
     {

--- a/kernel/src/eval/result.cpp
+++ b/kernel/src/eval/result.cpp
@@ -46,6 +46,17 @@ void Result::resize(Index clauses, Index vars)
 
 void Result::fill(float v, Index clause)
 {
+    setValue(v, clause);
+
+    // Fill the Jacobian row with zeros
+    for (auto& d : j[clause])
+    {
+        d = 0;
+    }
+}
+
+void Result::setValue(float v, Index clause)
+{
     for (unsigned i=0; i < N; ++i)
     {
         f[clause][i] = v;
@@ -55,12 +66,6 @@ void Result::fill(float v, Index clause)
     }
 
     i[clause] = Interval(v, v);
-
-    // Fill the Jacobian row with zeros
-    for (auto& d : j[clause])
-    {
-        d = 0;
-    }
 }
 
 void Result::setJacobian(Index clause, Index var)

--- a/kernel/src/tree/cache.cpp
+++ b/kernel/src/tree/cache.cpp
@@ -65,6 +65,14 @@ Cache::Id Cache::constant(float v)
     return data.left.at(k);
 }
 
+Cache::Id Cache::var(float v)
+{
+    auto k = Key(v, next);
+    assert(data.left.find(k) == data.left.end());
+    data.insert({k, next++});
+    return data.left.at(k);
+}
+
 Cache::Id Cache::operation(Opcode::Opcode op, Id a, Id b, bool collapse)
 {
     // These are opcodes that you're not allowed to use here

--- a/kernel/src/tree/opcode.cpp
+++ b/kernel/src/tree/opcode.cpp
@@ -28,6 +28,7 @@ size_t Opcode::args(Opcode op)
         case VAR_X:
         case VAR_Y:
         case VAR_Z:
+        case VAR:
             return 0;
 
         case SQUARE: // fallthrough
@@ -77,6 +78,7 @@ std::string Opcode::to_str(Opcode op)
         case Opcode::VAR_X: return "X";
         case Opcode::VAR_Y: return "Y";
         case Opcode::VAR_Z: return "Z";
+        case Opcode::VAR: return "var";
         case Opcode::ADD: return "add";
         case Opcode::MUL: return "mul";
         case Opcode::MIN: return "min";

--- a/kernel/src/tree/tree.cpp
+++ b/kernel/src/tree/tree.cpp
@@ -57,6 +57,12 @@ Tree Tree::affine(float a, float b, float c, float d)
     return Tree(s, s->affine(a, b, c, d));
 }
 
+Tree Tree::var(float v)
+{
+    auto s = Cache::instance();
+    return Tree(s, s->var(v));
+}
+
 Tree Tree::collapse() const
 {
     return collapsed ? *this :

--- a/kernel/test/cache.cpp
+++ b/kernel/test/cache.cpp
@@ -160,3 +160,12 @@ TEST_CASE("Cache::findConnected")
     auto connected = t->findConnected(t->X());
     REQUIRE(connected.size() == 1);
 }
+
+TEST_CASE("Cache::var")
+{
+    Cache::reset();
+    auto t = Cache::instance();
+    auto a = t->var(3.1);
+    auto b = t->var(3.2);
+    REQUIRE(a != b);
+}

--- a/kernel/test/eval.cpp
+++ b/kernel/test/eval.cpp
@@ -45,26 +45,29 @@ TEST_CASE("Evaluator::gradient")
 {
     SECTION("constant + variable")
     {
-        Evaluator e(Tree(Opcode::ADD, Tree::var(3.14), Tree(1.0)));
+        auto v = Tree::var(3.14);
+        Evaluator e(Tree(Opcode::ADD, v, Tree(1.0)));
         REQUIRE(e.eval(1.0, 2.0, 3.0) == Approx(4.14));
         auto g = e.gradient();
         REQUIRE(g.size() == 1);
-        REQUIRE(g[0] == Approx(1));
+        REQUIRE(g.count(v.var()) == 1);
+        REQUIRE(g[v.var()] == Approx(1));
     }
 
     SECTION("x * variable")
     {
-        Evaluator e(Tree(Opcode::MUL, Tree::X(), Tree::var(1.0)));
+        auto v = Tree::var(1.0);
+        Evaluator e(Tree(Opcode::MUL, Tree::X(), v));
         {
             REQUIRE(e.eval(2.0, 2.0, 3.0) == Approx(2.0));
             auto g = e.gradient();
             REQUIRE(g.size() == 1);
-            REQUIRE(g[0] == Approx(2));
+            REQUIRE(g[v.var()] == Approx(2));
         }
         {
             REQUIRE(e.eval(3.0, 2.0, 3.0) == Approx(3.0));
             auto g = e.gradient();
-            REQUIRE(g[0] == Approx(3));
+            REQUIRE(g[v.var()] == Approx(3));
         }
     }
 

--- a/kernel/test/eval.cpp
+++ b/kernel/test/eval.cpp
@@ -54,17 +54,30 @@ TEST_CASE("Evaluator::gradient")
 
     SECTION("x * variable")
     {
-        Evaluator e(Tree(Opcode::MUL, Tree::X(), Tree(1.0)));
-        REQUIRE(e.eval(2.0, 2.0, 3.0) == Approx(2.0));
+        Evaluator e(Tree(Opcode::MUL, Tree::X(), Tree::var(1.0)));
         {
+            REQUIRE(e.eval(2.0, 2.0, 3.0) == Approx(2.0));
             auto g = e.gradient();
+            REQUIRE(g.size() == 1);
             REQUIRE(g[0] == Approx(2));
         }
-        REQUIRE(e.eval(3.0, 2.0, 3.0) == Approx(3.0));
         {
+            REQUIRE(e.eval(3.0, 2.0, 3.0) == Approx(3.0));
             auto g = e.gradient();
             REQUIRE(g[0] == Approx(3));
         }
+    }
+
+    SECTION("Multiple variables")
+    {
+        auto a = Tree::var(3.0);
+        auto b = Tree::var(5.0);
+        auto c = Tree::var(7.0);
+        Evaluator e(Tree(Opcode::ADD, Tree(Opcode::ADD,
+            Tree(Opcode::MUL, Tree(1.0f), a),
+            Tree(Opcode::MUL, Tree(2.0f), b)),
+            Tree(Opcode::MUL, Tree(3.0f), c)));
+        REQUIRE(e.eval(0, 0, 0) == Approx(34));
     }
 }
 

--- a/kernel/test/eval.cpp
+++ b/kernel/test/eval.cpp
@@ -22,7 +22,7 @@
 #include "ao/kernel/tree/tree.hpp"
 #include "ao/kernel/eval/evaluator.hpp"
 
-TEST_CASE("Variable evaluation")
+TEST_CASE("Principle variable evaluation")
 {
     Evaluator e(Tree::X());
 
@@ -32,6 +32,12 @@ TEST_CASE("Variable evaluation")
 TEST_CASE("Constant evaluation")
 {
     Evaluator e(Tree(3.14));
+    REQUIRE(e.eval(1.0, 2.0, 3.0) == Approx(3.14));
+}
+
+TEST_CASE("Secondary variable evaluation")
+{
+    Evaluator e(Tree::var(3.14));
     REQUIRE(e.eval(1.0, 2.0, 3.0) == Approx(3.14));
 }
 

--- a/kernel/test/eval.cpp
+++ b/kernel/test/eval.cpp
@@ -51,6 +51,21 @@ TEST_CASE("Evaluator::gradient")
         REQUIRE(g.size() == 1);
         REQUIRE(g[0] == Approx(1));
     }
+
+    SECTION("x * variable")
+    {
+        Evaluator e(Tree(Opcode::MUL, Tree::X(), Tree(1.0)));
+        REQUIRE(e.eval(2.0, 2.0, 3.0) == Approx(2.0));
+        {
+            auto g = e.gradient();
+            REQUIRE(g[0] == Approx(2));
+        }
+        REQUIRE(e.eval(3.0, 2.0, 3.0) == Approx(3.0));
+        {
+            auto g = e.gradient();
+            REQUIRE(g[0] == Approx(3));
+        }
+    }
 }
 
 TEST_CASE("Float evaluation")

--- a/kernel/test/eval.cpp
+++ b/kernel/test/eval.cpp
@@ -41,6 +41,18 @@ TEST_CASE("Secondary variable evaluation")
     REQUIRE(e.eval(1.0, 2.0, 3.0) == Approx(3.14));
 }
 
+TEST_CASE("Evaluator::gradient")
+{
+    SECTION("constant + variable")
+    {
+        Evaluator e(Tree(Opcode::ADD, Tree::var(3.14), Tree(1.0)));
+        REQUIRE(e.eval(1.0, 2.0, 3.0) == Approx(4.14));
+        auto g = e.gradient();
+        REQUIRE(g.size() == 1);
+        REQUIRE(g[0] == Approx(1));
+    }
+}
+
 TEST_CASE("Float evaluation")
 {
     SECTION("X + 1")

--- a/kernel/test/eval.cpp
+++ b/kernel/test/eval.cpp
@@ -48,10 +48,10 @@ TEST_CASE("Evaluator::gradient")
         auto v = Tree::var(3.14);
         Evaluator e(Tree(Opcode::ADD, v, Tree(1.0)));
         REQUIRE(e.eval(1.0, 2.0, 3.0) == Approx(4.14));
-        auto g = e.gradient();
+        auto g = e.gradient(1, 2, 3);
         REQUIRE(g.size() == 1);
         REQUIRE(g.count(v.var()) == 1);
-        REQUIRE(g[v.var()] == Approx(1));
+        REQUIRE(g.at(v.var()) == Approx(1));
     }
 
     SECTION("x * variable")
@@ -59,29 +59,54 @@ TEST_CASE("Evaluator::gradient")
         auto v = Tree::var(1.0);
         Evaluator e(Tree(Opcode::MUL, Tree::X(), v));
         {
-            REQUIRE(e.eval(2.0, 2.0, 3.0) == Approx(2.0));
-            auto g = e.gradient();
+            auto g = e.gradient(2, 0, 0);
             REQUIRE(g.size() == 1);
-            REQUIRE(g[v.var()] == Approx(2));
+            REQUIRE(g.at(v.var()) == Approx(2));
         }
         {
-            REQUIRE(e.eval(3.0, 2.0, 3.0) == Approx(3.0));
-            auto g = e.gradient();
-            REQUIRE(g[v.var()] == Approx(3));
+            auto g = e.gradient(3, 0, 0);
+            REQUIRE(g.at(v.var()) == Approx(3));
         }
     }
 
     SECTION("Multiple variables")
     {
+        // Deliberately construct out of order
         auto a = Tree::var(3.0);
-        auto b = Tree::var(5.0);
         auto c = Tree::var(7.0);
+        auto b = Tree::var(5.0);
+
         Evaluator e(Tree(Opcode::ADD, Tree(Opcode::ADD,
             Tree(Opcode::MUL, Tree(1.0f), a),
             Tree(Opcode::MUL, Tree(2.0f), b)),
             Tree(Opcode::MUL, Tree(3.0f), c)));
         REQUIRE(e.eval(0, 0, 0) == Approx(34));
+        auto g = e.gradient(0, 0, 0);
+        REQUIRE(g.at(a.var()) == Approx(1.0f));
+        REQUIRE(g.at(b.var()) == Approx(2.0f));
+        REQUIRE(g.at(c.var()) == Approx(3.0f));
     }
+}
+
+TEST_CASE("Evaluator::setVar")
+{
+    // Deliberately construct out of order
+    auto a = Tree::var(3.0);
+    auto c = Tree::var(7.0);
+    auto b = Tree::var(5.0);
+
+    Evaluator e(Tree(Opcode::ADD, Tree(Opcode::ADD,
+        Tree(Opcode::MUL, Tree(1.0f), a),
+        Tree(Opcode::MUL, Tree(2.0f), b)),
+        Tree(Opcode::MUL, Tree(3.0f), c)));
+    REQUIRE(e.eval(0, 0, 0) == Approx(34));
+
+    e.setVar(a.var(), 5);
+    REQUIRE(e.eval(0, 0, 0) == Approx(36));
+    e.setVar(b.var(), 0);
+    REQUIRE(e.eval(0, 0, 0) == Approx(26));
+    e.setVar(c.var(), 10);
+    REQUIRE(e.eval(0, 0, 0) == Approx(35));
 }
 
 TEST_CASE("Float evaluation")

--- a/kernel/test/tree.cpp
+++ b/kernel/test/tree.cpp
@@ -156,3 +156,16 @@ TEST_CASE("Tree::collapse")
         REQUIRE(t_.opcode() == Opcode::VAR_X);
     }
 }
+
+TEST_CASE("Tree::var")
+{
+    Cache::reset();
+
+    auto a = Tree::var(3.0);
+    auto b = Tree::var(5.0);
+    auto c = Tree::var(7.0);
+
+    REQUIRE(a.var() == 1);
+    REQUIRE(b.var() == 2);
+    REQUIRE(c.var() == 3);
+}


### PR DESCRIPTION
This PR adds a new opcode, `VAR`, which reflects an independent variable with some default value.  It also adds `Evaluator::gradient`, which returns the gradient with respect to all `VAR` clauses, and `Evaluator::setVar` to change a value.

This is laying the groundwork for a gradient-descent based constraint solver.