### PR TITLE
Log

### DIFF
--- a/ao/bind/ao-guile.cpp
+++ b/ao/bind/ao-guile.cpp
@@ -277,6 +277,7 @@ void init_ao_kernel(void*)
 (define-method (exp (a <tree>)) (make-tree 'exp a))
 (define-method (abs (a <tree>)) (make-tree 'abs a))
 (define-method (atan (a <tree>)) (make-tree 'atan a))
+(define-method (log (a <tree>)) (make-tree 'log a))
 (define-method (constant (a <tree>)) (make-tree 'const-var a))
 (define (square f) (if (tree? f) (make-tree 'square f) (* f f)))
 

--- a/ao/include/ao/tree/opcode.hpp
+++ b/ao/include/ao/tree/opcode.hpp
@@ -49,6 +49,7 @@ namespace Opcode
     OPCODE(ATAN, 15)        \
     OPCODE(EXP, 16)         \
     OPCODE(ABS, 28)         \
+    OPCODE(LOG, 30)         \
     OPCODE(RECIP, 29)       \
                             \
     OPCODE(ADD, 17)         \
@@ -67,7 +68,7 @@ enum Opcode {
 #define OPCODE(s, i) s=i,
     OPCODES
 #undef OPCODE
-    LAST_OP=30,
+    LAST_OP=31,
 };
 
 size_t args(Opcode op);

--- a/ao/include/ao/tree/tree.hpp
+++ b/ao/include/ao/tree/tree.hpp
@@ -191,6 +191,7 @@ OP_UNARY(tan);
 OP_UNARY(asin);
 OP_UNARY(acos);
 OP_UNARY(atan);
+OP_UNARY(log);
 OP_UNARY(exp);
 #undef OP_UNARY
 

--- a/ao/src/eval/eval_affine.cpp
+++ b/ao/src/eval/eval_affine.cpp
@@ -259,6 +259,8 @@ void AffineEvaluator::operator()(Opcode::Opcode op, Clause::Id id,
                 ? Interval::I(-M_PI/2, M_PI/2)
                 : boost::numeric::atan(ai));
             break;
+        case Opcode::LOG:
+            setAffine(id, boost::numeric::log(ai));
         case Opcode::EXP:
             setAffine(id, boost::numeric::exp(ai));
             break;

--- a/ao/src/eval/eval_array.cpp
+++ b/ao/src/eval/eval_array.cpp
@@ -215,6 +215,9 @@ void ArrayEvaluator::operator()(Opcode::Opcode op, Clause::Id id,
         case Opcode::ATAN:
             out = atan(a);
             break;
+        case Opcode::LOG:
+            out = log(a);
+            break;
         case Opcode::EXP:
             out = exp(a);
             break;

--- a/ao/src/eval/eval_deriv.cpp
+++ b/ao/src/eval/eval_deriv.cpp
@@ -130,6 +130,9 @@ void DerivEvaluator::operator()(Opcode::Opcode op, Clause::Id id,
         case Opcode::ATAN:
             od = ad / (pow(av, 2) + 1);
             break;
+        case Opcode::LOG:
+            od = ad * log(av);
+            break;
         case Opcode::EXP:
             od = ad * exp(av);
             break;

--- a/ao/src/eval/eval_deriv_array.cpp
+++ b/ao/src/eval/eval_deriv_array.cpp
@@ -149,6 +149,9 @@ void DerivArrayEvaluator::operator()(Opcode::Opcode op, Clause::Id id,
         case Opcode::ATAN:
             od = ad.rowwise() / (pow(av, 2) + 1);
             break;
+        case Opcode::LOG:
+            od = ad.rowwise() * log(av);
+            break;
         case Opcode::EXP:
             od = ad.rowwise() * exp(av);
             break;

--- a/ao/src/eval/eval_interval.cpp
+++ b/ao/src/eval/eval_interval.cpp
@@ -193,6 +193,9 @@ void IntervalEvaluator::operator()(Opcode::Opcode op, Clause::Id id,
         case Opcode::EXP:
             out = boost::numeric::exp(a);
             break;
+        case Opcode::LOG:
+            out = boost::numeric::log(a);
+            break;
         case Opcode::ABS:
             out = boost::numeric::abs(a);
             break;

--- a/ao/src/eval/eval_jacobian.cpp
+++ b/ao/src/eval/eval_jacobian.cpp
@@ -141,6 +141,9 @@ void JacobianEvaluator::operator()(Opcode::Opcode op, Clause::Id id,
             case Opcode::ATAN:
                 oj = aj / (pow(av, 2) + 1);
                 break;
+            case Opcode::LOG:
+                oj = log(av) * aj;
+                break;
             case Opcode::EXP:
                 oj = exp(av) * aj;
                 break;

--- a/ao/src/eval/eval_point.cpp
+++ b/ao/src/eval/eval_point.cpp
@@ -185,6 +185,9 @@ void PointEvaluator::operator()(Opcode::Opcode op, Clause::Id id,
         case Opcode::ATAN:
             out = atan(a);
             break;
+        case Opcode::LOG:
+            out = log(a);
+            break;
         case Opcode::EXP:
             out = exp(a);
             break;

--- a/ao/src/tree/opcode.cpp
+++ b/ao/src/tree/opcode.cpp
@@ -48,6 +48,7 @@ size_t Opcode::args(Opcode op)
         case EXP:
         case CONST_VAR:
         case ABS:
+        case LOG:
         case RECIP:
             return 1;
 
@@ -162,6 +163,8 @@ std::string Opcode::toOpString(Opcode op)
         case NTH_ROOT:
         case MOD:
         case NANFILL:
+        case LOG:
+        case LOG10:
         case ABS:
             return toScmString(op);
 
@@ -206,6 +209,8 @@ bool Opcode::isCommutative(Opcode op)
         case MOD:
         case NANFILL:
         case INVALID:
+        case LOG:
+        case LOG10:
         case ABS:
         case RECIP:
         case CONST_VAR:

--- a/ao/src/tree/opcode.cpp
+++ b/ao/src/tree/opcode.cpp
@@ -164,7 +164,6 @@ std::string Opcode::toOpString(Opcode op)
         case MOD:
         case NANFILL:
         case LOG:
-        case LOG10:
         case ABS:
             return toScmString(op);
 
@@ -210,7 +209,6 @@ bool Opcode::isCommutative(Opcode op)
         case NANFILL:
         case INVALID:
         case LOG:
-        case LOG10:
         case ABS:
         case RECIP:
         case CONST_VAR:

--- a/ao/src/tree/tree.cpp
+++ b/ao/src/tree/tree.cpp
@@ -237,6 +237,7 @@ OP_UNARY(tan,       Kernel::Opcode::TAN)
 OP_UNARY(asin,      Kernel::Opcode::ASIN)
 OP_UNARY(acos,      Kernel::Opcode::ACOS)
 OP_UNARY(atan,      Kernel::Opcode::ATAN)
+OP_UNARY(log,       Kernel::Opcode::LOG)
 OP_UNARY(exp,       Kernel::Opcode::EXP)
 #undef OP_UNARY
 


### PR DESCRIPTION
I added the `log` function to the set of math functions. It seems to work fine in some cases (`egg` below) and fail on other (`glass`). I am not sure my change introduced those errors or how to protect from them.

```scheme
(define (glass)
(lambda-shape (x y z)
  (+ (* x x) (* y y) (* (log (+ z 3.2)) (log (+ z 3.2))) 0.02))
)


(define (egg)
(lambda-shape (x y z)
  (+ (* x x) (* y y) (* (log (+ z 3.2)) z) 0.02))
)
```